### PR TITLE
test excess authority via prototype chain (WIP)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,16 @@
+These tests are written in the style of [test262].
+
+[test262]: https://github.com/tc39/test262
+
+## Packaging for use with Test262 Web Runner
+
+The [web runner][1] expects a zip file shaped like test262.
+I cobbled one together that seems to work thus:
+
+    ~/projects$ git clone https://github.com/tc39/test262.git
+    ~/projects$ cd proposal-realms
+    ~/projects/proposal-realms$ ln -s ~/projects/test262/harness
+    ~/projects/proposal-realms$ zip -r /tmp/realmTests.zip test/ harness/
+    
+[1] https://bakkot.github.io/test262-web-runner/
+

--- a/test/README.md
+++ b/test/README.md
@@ -5,11 +5,13 @@ These tests are written in the style of [test262].
 ## Packaging for use with Test262 Web Runner
 
 The [web runner][1] expects a zip file shaped like test262.
-I cobbled one together that seems to work thus:
+I cobbled one together that seems to work as follows; note the
+addition of `realm-shim.js` to the harness:
 
     ~/projects$ git clone https://github.com/tc39/test262.git
     ~/projects$ cd proposal-realms
     ~/projects/proposal-realms$ ln -s ~/projects/test262/harness
+    ~/projects/proposal-realms$ cp shim/dist/realm-shim.js harness/
     ~/projects/proposal-realms$ zip -r /tmp/realmTests.zip test/ harness/
     
 [1] https://bakkot.github.io/test262-web-runner/

--- a/test/helloFail.js
+++ b/test/helloFail.js
@@ -1,0 +1,8 @@
+// Copyright (C) 2016 Dan Connolly. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: experimental failing test
+---*/
+
+throw('you lose!');

--- a/test/helloPass.js
+++ b/test/helloPass.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Dan Connolly. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: experimental passing test
+---*/
+
+'you win!';
+

--- a/test/prototypeWalkingProblem.js
+++ b/test/prototypeWalkingProblem.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 Dan Connolly. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: incompletely confined realms
+ includes: [realm-shim.js]
+ info: >
+   See slide "Is Alice's API surface defensive?" at 22:15 in
+   https://drive.google.com/file/d/0Bw0VXJKBgYPMeFRjenpFb0dYNnM/view
+---*/
+
+function Alice() {
+    //const rootA = Realm.immutableRoot();
+    const rootA = new RealmShim();
+
+    function confine(src, endowments) {
+        // TODO: as of 13 Dec 3d2eb02, .spawn() is not
+        // supported by the shim, so we get:
+        //   TypeError: rootA.spawn is not a function
+        return rootA.spawn(endowments).eval(src);
+    }
+    function Counter() {
+        let count = 0;
+        return Object.freeze({
+            incr: () => ++count,
+            decr: () => --count
+        });
+    }
+
+    const counter = Counter();
+
+    const bobSrc = String(Bob);
+    const bob = confine(bobSrc, {change: counter.incr});
+    //const carol = confine(carlSrc, {change: counter.decr});
+}
+
+function Bob() {
+    let stash = null;
+    change.__proto__.__proto__.toString = function() { stash = this; };
+    // TODO: come back in a later turn when Alice has called toString
+    // and we can exploit the stash.
+}
+
+Alice();


### PR DESCRIPTION
I'm trying to make an automated test out of the `change.__proto__.__proto__.toString` example.

As of 13 Dec 3d2eb02, the shim doesn't seem to support `.spawn()`. I get: `TypeError: rootA.spawn is not a function`. I'm a little confused about which proposal the shim is aimed at.

Meanwhile, re #25 running tests from test-262 inside the shim, I think this shows progress. Once I added `realm-shim.js` under `harness/`, all I had to do was add:

```
 includes: [realm-shim.js]
```

to the test metadata.

This is WIP. I'm not actually requesting that this code get merged as is; just reporting progress and asking for clarification/direction.

cc @caridy @erights @jfparadis @FUDCo