### PR TITLE
Refactor to introduce the `importHook`

### DIFF
--- a/spec/index.emu
+++ b/spec/index.emu
@@ -34,28 +34,6 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
     </table>
 </emu-table>
 
-<emu-table id="table-2" caption="Well-known Symbols">
-    <table>
-        <tbody>
-            <tr>
-                <th>Specification Name</th>
-                <th>[[Description]]</th>
-                <th>Value and Purpose</th>
-            </tr>
-            <tr>
-                <td>@@indirectEval</td>
-                <td><code>Realm.indirectEval</code></td>
-                <td>A function valued property that is the indirectEval hook function of Realm’s instances.</td>
-            </tr>
-            <tr>
-                <td>@@directEval</td>
-                <td><code>Realm.directEval</code></td>
-                <td>A function valued property that is the directEval hook function of Realm’s instances.</td>
-            </tr>
-        </tbody>
-    </table>
-</emu-table>
-
 <emu-table id="table-2" caption="Realm Record Fields">
     <table>
         <tbody>
@@ -70,14 +48,19 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
                 <td>...</td>
             </tr>
             <tr>
-                <td>[[IndirectEval]]</td>
-                <td>Object | Undefined</td>
-                <td>If the value is an Object it must be a function object. The function is call prior to perform any indirect evaluation in the realm.</td>
+                <td>[[EvalHook]]</td>
+                <td>A function object or *undefined*</td>
+                <td>The function that is used as the eval hook. If [[EvalHook]] is undefined, a function that returns the original source text value will be used instead.</td>
             </tr>
             <tr>
-                <td>[[DirectEval]]</td>
-                <td>Object | Undefined</td>
-                <td>If the value is an Object it must be a function object. The function is call prior to perform any direct evaluation in the realm.</td>
+                <td>[[ImportHook]]</td>
+                <td>A function object or *undefined*</td>
+                <td>The function that is used as the import hook. If [[ImportHook]] is undefined, a function that returns a rejected promise value will be used instead.</td>
+            </tr>
+            <tr>
+                <td>[[IsUserCreated]]</td>
+                <td>Boolean</td>
+                <td>Determines whether the Realm was created in user-land.</td>
             </tr>
         </tbody>
     </table>
@@ -178,43 +161,36 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
   <emu-alg>
     1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
     1. <ins>If _direct_ is *true*, then</ins>
-      1. <ins>Let _xValue_ be ? PrepareForDirectEval(_x_, _evalRealm_).</ins>
-    1. <ins>Else,</ins>
-      1. <ins>Let _xValue_ be ? PrepareForIndirectEval(_x_, _evalRealm_).</ins>
+      1. <ins>Let _xValue_ be ? InvokeEvalHook(_x_, _evalRealm_).</ins>
     1. If Type(_xValue_) is not String, return _xValue_.
-    1. Let _script_ be the ECMAScript code that is the result of parsing _xValue_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>). Parsing and early error detection may be interweaved in an implementation dependent manner.
-    1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
-    1. Let _body_ be the |ScriptBody| of _script_.
-    1. If _strictCaller_ is *true*, let _strictEval_ be *true*.
-    1. Else, let _strictEval_ be IsStrict of _script_.
-    1. Let _ctx_ be the running execution context. If _direct_ is *true*, _ctx_ will be the execution context that performed the direct eval. If _direct_ is *false*, _ctx_ will be the execution context for the invocation of the `eval` function.
-    1. If _direct_ is *true*, then
-      1. Let _lexEnv_ be NewDeclarativeEnvironment(_ctx_'s LexicalEnvironment).
-      1. Let _varEnv_ be _ctx_'s VariableEnvironment.
-    1. Else,
-      1. Let _lexEnv_ be NewDeclarativeEnvironment(_evalRealm_.[[GlobalEnv]]).
-      1. Let _varEnv_ be _evalRealm_.[[GlobalEnv]].
-    1. If _strictEval_ is *true*, let _varEnv_ be _lexEnv_.
-    1. If _ctx_ is not already suspended, suspend _ctx_.
-    1. Let _evalCxt_ be a new ECMAScript code execution context.
-    1. Set the _evalCxt_'s Function to *null*.
-    1. Set the _evalCxt_'s Realm to _evalRealm_.
-    1. Set the _evalCxt_'s ScriptOrModule to _ctx_'s ScriptOrModule.
-    1. Set the _evalCxt_'s VariableEnvironment to _varEnv_.
-    1. Set the _evalCxt_'s LexicalEnvironment to _lexEnv_.
-    1. Push _evalCxt_ on to the execution context stack; _evalCxt_ is now the running execution context.
-    1. Let _result_ be EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _strictEval_).
-    1. If _result_.[[Type]] is ~normal~, then
-      1. Let _result_ be the result of evaluating _body_.
-    1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
-      1. Let _result_ be NormalCompletion(*undefined*).
-    1. Suspend _evalCxt_ and remove it from the execution context stack.
-    1. Resume the context that is now on the top of the execution context stack as the running execution context.
-    1. Return Completion(_result_).
+    1. ...
   </emu-alg>
-  <emu-note>
-    <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if the calling context is evaluating formal parameter initializers or if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
-  </emu-note>
+</emu-clause>
+
+<emu-clause id="sec-import-calls">
+  <h1><ins>Import Calls</ins></h1>
+
+  <emu-clause id="sec-import-call-runtime-semantics-evaluation">
+    <h1>Runtime Semantics: Evaluation</h1>
+
+    <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
+    <emu-alg>
+    1. Let _referencingScriptOrModule_ be ! GetActiveScriptOrModule().
+    1. Assert: _referencingScriptOrModule_ is a Script Record or Module Record (i.e. is not *null*).
+    1. Let _argRef_ be the result of evaluating |AssignmentExpression|.
+    1. Let _specifier_ be ? GetValue(_argRef_).
+    1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+    1. Let _specifierString_ be ToString(_specifier_).
+    1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+    1. <ins>Let _ctx_ be the running execution context</ins>.
+    1. <ins>Let _currentRealm_ be ctx's Realm</ins>.
+    1. <ins>If _currentRealm_.[[IsUserCreated]] is *true*, then</ins>
+      1. <ins>Return ? InvokeImportHook(_referencingScriptOrModule_, _specifierString_).</ins>
+    1. <ins>Else,</ins>
+      1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, _promiseCapability_).
+    1. Return _promiseCapability_.[[Promise]].
+    </emu-alg>
+  </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-realm-objects">
@@ -223,56 +199,46 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
     <emu-clause id="sec-realm-abstract-operations">
         <h1>Realm Abstract Operations</h1>
 
-        <emu-clause id="sec-preparefordirecteval" aoid="PrepareForDirectEval">
-            <h1>PrepareForDirectEval ( _x_, _realmRec_ )</h1>
+        <emu-clause id="sec-invokeevalhook" aoid="InvokeEvalHook">
+            <h1>InvokeEvalHook ( _realmRec_, _x_ )</h1>
 
-            <p>The abstract operation PrepareForDirectEval with arguments _x_ and _realmRec_ performs the following steps:</p>
+            <p>The abstract operation InvokeEvalHook with arguments _realmRec_ and _x_ performs the following steps:</p>
 
             <emu-alg>
             1. Assert: realm is a Realm Record.
-            1. Let _fn_ be _realmRec_.[[DirectEval]].
+            1. Let _fn_ be _realmRec_.[[EvalHook]].
             1. If _fn_ is *undefined*, return _x_.
             1. Assert: IsCallable(_fn_) is *true*.
             1. Return ? Call(_fn_, *undefined*, « _x_ »).
             </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-prepareforindirecteval" aoid="PrepareForIndirectEval">
-            <h1>PrepareForIndirectEval ( _x_, _realmRec_ )</h1>
+        <emu-clause id="sec-invokeimporthook" aoid="InvokeImportHook">
+            <h1>InvokeImportHook ( _realmRec_, _referencingScriptOrModule_, _specifier_ )</h1>
 
-            <p>The abstract operation PrepareForIndirectEval with arguments _x_ and _realmRec_ performs the following steps:</p>
+            <p>The abstract operation InvokeImportHook with arguments _realmRec_, _referencingScriptOrModule_, and _specifier_ performs the following steps:</p>
 
             <emu-alg>
-            1. Assert: realm is a Realm Record.
-            1. Let _fn_ be _realmRec_.[[IndirectEval]].
-            1. If _fn_ is *undefined*, return _x_.
-            1. Assert: IsCallable(_fn_) is *true*.
-            1. Return ? Call(_fn_, *undefined*, « _x_ »).
+            1. Assert: _realmRec_ is a Realm Record.
+            1. Assert: Type(_specifier_) is String.
+            1. Assert: _referencingScriptOrModule_ is a Script Record or Module Record (i.e. is not null).
+            1. Let _fn_ be _realmRec_.[[ImportHook]].
+            1. If _fn_ is *undefined*, then
+              1. Return a promise rejected with a new *TypeError* exception.
+            1. If _referencingScriptOrModule_ is a Module Record, then
+              1. Assert: ModuleEvaluation has already been invoked on _referencingScriptOrModule_ and successfully completed.
+              1. Let _ns_ be GetModuleNamespace(_referencingScriptOrModule_).
+              1. If _ns_ is an abrupt completion, return a promise rejected with _namespace_.[[Value]].
+            1. Else,
+              1. Let _ns_ be *null*.
+            1. Let _p_ be Call(_fn_, *undefined*, « _ns_, _specifier_ »).
+            1. If _p_ is an abrupt completion, then
+              1. return a promise rejected with _p_.[[Value]].
+            1. Else,
+              1. If _p_ is a Completion Record, return _p_.[[Value]].
             </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-extract-realm-methods" aoid="ExtractRealmMethods">
-            <h1>ExtractRealmMethods ( _realmObj_ )</h1>
-
-            When ExtractRealmMethods is called with argument _realmObj_ performs the following steps:
-
-            <emu-alg>
-            1. Assert: Type(_realmObj_) is not Object, throw a *TypeError* exception.
-            1. Assert: _realmObj_ does have an [[Realm]] internal slot, throw a *TypeError* exception.
-            1. Let _realmRec_ be _realmObj_.[[Realm]].
-            1. Let _directEvalFn_ be ? GetMethod(_realmObj_, @@directEval).
-            1. If IsCallable(_directEvalFn_) is not *true*, throw a *TypeError* exception.
-            1. Let _boundDirectEvalFn_ be BoundFunctionCreate(_directEvalFn_, _realmObj_, « »).
-            1. Perform ! DefinePropertyOrThrow(_boundDirectEvalFn_, "length", PropertyDescriptor {[[Value]]: 2, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-            1. Set _realmRec_'s [[DirectEval]] internal slot to _boundDirectEvalFn_.
-            1. Let _indirectEvalFn_ be ? GetMethod(_realmObj_, @@indirectEval).
-            1. If IsCallable(_indirectEvalFn_) is not *true*, throw a *TypeError* exception.
-            1. Let _boundIndirectEvalFn_ be BoundFunctionCreate(_indirectEvalFn_, _realmObj_, « »).
-            1. Perform ! DefinePropertyOrThrow(_boundIndirectEvalFn_, "length", PropertyDescriptor {[[Value]]: 1, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-            1. Set _realmRec_'s [[IndirectEval]] internal slot to _boundIndirectEvalFn_.
-            </emu-alg>
-
-        </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-the-realm-constructor">
@@ -287,23 +253,31 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
         </p>
 
         <emu-clause id="sec-realm" aoid="Realm">
-            <h1>Realm ([ _target_, _handler_ ])</h1>
+            <h1>Realm ([ _options_ ])</h1>
 
-            When Realm is called with arguments _target_ and _handler_ performs the following steps:
+            When Realm is called with argument _option_ performs the following steps:
 
             <emu-alg>
             1. If NewTarget is *undefined*, throw a *TypeError* exception.
             1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, "%RealmPrototype%", « [[Realm]] »).
-            1. If _handler_ is provided, then:
-              1. If Type(_target_) is not Object, throw a *TypeError* exception.
-              1. If Type(_handler_) is not Object, throw a *TypeError* exception.
-              1. Let _globalEnv_ be ? ProxyCreate(_target_, _handler_).
-            1. Else,
-              1. Let _globalEnv_ be *undefined*.
+            1. If _options_ is not *undefined*, then
+              1. Let _opts_ be ? ToObject(_options_).
+              1. Let _importHook_ be ? Get(_opts_, "importHook").
+              1. If _importHook_ is not *undefined* and IsCallable(_importHook_) is *false*, throw a TypeError exception.
+              1. Let _evalHook_ be ? Get(_opts_, "importHook").
+              1. If _evalHook_ is not *undefined* and IsCallable(_evalHook_) is *false*, throw a TypeError exception.
+              1. Let _thisValue_ be ? Get(_opts_, "thisValue").
+              1. If _thisValue_ is not *undefined* and Type(_thisValue_) is not Object, throw a TypeError exception.
+              1. Let _globalObj_ be ? Get(_opts_, "globalObj").
+              1. If _globalObj_ is not *undefined* and Type(_globalObj_) is not Object, throw a TypeError exception.
             1. Let _realmRec_ be CreateRealm().
-            1. Set _O_'s [[Realm]] internal slot to _realmRec_.
-            1. Perform ? ExtractRealmMethods(_O_).
-            1. Perform ? SetRealmGlobalObject(_realmRec_, _globalEnv_, *undefined*).
+            1. Set _O_.[[Realm]] to _realmRec_.
+            1. Perform ? SetRealmGlobalObject(_realmRec_, _globalObj_, _thisValue_).
+            1. Set _realmRec_.[[IsUserCreated]] to *true*.
+            1. If _evalHook_ is not *undefined*, then
+              1. Set _realmRec_.[[directEval]] to _evalHook_.
+            1. If _importHook_ is not *undefined*, then
+              1. Set _realmRec_.[[directImport]] to _importHook_.
             1. Let _init_ be ? GetMethod(_O_, *"init"*).
             1. If IsCallable(_init_) is not *true*, throw a *TypeError* exception.
             1. Perform ? Call(_init_, _O_).
@@ -357,36 +331,6 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
             </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-realm.prototype-@@directEval">
-            <h1>Realm.prototype [ @@directEval ] ( _x_ )</h1>
-
-            <emu-alg>
-            1. Let _O_ be *this* value.
-            1. If Type(_O_) is not Object, throw a *TypeError* exception.
-            1. If _O_ does not have an [[Realm]] internal slot, throw a *TypeError* exception.
-            1. Return _x_.
-            </emu-alg>
-
-            <emu-note>
-                Extensible web: This is the hook to pre-process _x_ as the code to be evaluated by calling <code>eval()</code>.
-            </emu-note>
-        </emu-clause>
-
-        <emu-clause id="sec-realm.prototype-@@indirectEval">
-            <h1>Realm.prototype [ @@indirectEval ] ( _x_ )</h1>
-
-            <emu-alg>
-            1. Let _O_ be *this* value.
-            1. If Type(_O_) is not Object, throw a *TypeError* exception.
-            1. If _O_ does not have an [[Realm]] internal slot, throw a *TypeError* exception.
-            1. Return _x_.
-            </emu-alg>
-
-            <emu-note>
-                Extensible web: This is the hook to pre-process _x_ as the code to be evaluated by calling a reference to the <code>eval</code> function.
-            </emu-note>
-        </emu-clause>
-
         <emu-clause id="sec-realm.prototype.global">
             <h1>get Realm.prototype.global</h1>
 
@@ -397,6 +341,20 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have an [[Realm]] internal slot, throw a *TypeError* exception.
             1. Return _O_.[[Realm]].[[GlobalObject]].
+            </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-realm.prototype.thisValue">
+            <h1>get Realm.prototype.thisValue</h1>
+
+            Realm.prototype.thisValue is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
+
+            <emu-alg>
+            1. Let _O_ be *this* value.
+            1. If Type(_O_) is not Object, throw a *TypeError* exception.
+            1. If _O_ does not have an [[Realm]] internal slot, throw a *TypeError* exception.
+            1. Let _envRec_ be _O_.[[Realm]].[[GlobalEnv]].
+            1. Return _envRec_.[[GlobalThisValue]].
             </emu-alg>
         </emu-clause>
 

--- a/spec/index.emu
+++ b/spec/index.emu
@@ -34,7 +34,11 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
     </table>
 </emu-table>
 
-<emu-table id="table-2" caption="Realm Record Fields">
+<!-- es6num="8.2" -->
+<emu-clause id="sec-code-realms">
+  <h1>Realms</h1>
+
+  <emu-table id="table-21" caption="Realm Record Fields">
     <table>
         <tbody>
             <tr>
@@ -50,21 +54,76 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
             <tr>
                 <td>[[EvalHook]]</td>
                 <td>A function object or *undefined*</td>
-                <td>The function that is used as the eval hook. If [[EvalHook]] is undefined, a function that returns the original source text value will be used instead.</td>
+                <td>The function that is used as the eval hook. If [[EvalHook]] is undefined, the hook invoker will carry on the default behavior.</td>
+            </tr>
+            <tr>
+                <td>[[IsDirectEvalHook]]</td>
+                <td>A function object or *undefined*</td>
+                <td>The function that is used as the direct eval check hook. If [[IsDirectEvalHook]] is undefined, the hook invoker will carry on the default behavior.</td>
             </tr>
             <tr>
                 <td>[[ImportHook]]</td>
                 <td>A function object or *undefined*</td>
-                <td>The function that is used as the import hook. If [[ImportHook]] is undefined, a function that returns a rejected promise value will be used instead.</td>
-            </tr>
-            <tr>
-                <td>[[IsUserCreated]]</td>
-                <td>Boolean</td>
-                <td>Determines whether the Realm was created in user-land.</td>
+                <td>The function that is used as the import hook. If [[ImportHook]] is undefined, the hook invoker will carry on the default behavior.</td>
             </tr>
         </tbody>
     </table>
-</emu-table>
+  </emu-table>
+
+  <emu-clause id="sec-invokeisdirectevalhook" aoid="InvokeIsDirectEvalHook">
+    <h1>InvokeIsDirectEvalHook(_realmRec_, _func_)</h1>
+    <p>The abstract operation InvokeIsDirectEvalHook with arguments _realmRec_ and _func_ performs the following steps:</p>
+    <emu-alg>
+      1. Assert: realm is a Realm Record.
+      1. Let _fn_ be _realmRec_.[[IsDirectEvalHook]].
+      1. If _fn_ is *undefined*, return SameValue(_func_, %eval%).
+      1. Assert: IsCallable(_fn_) is *true*.
+      1. Let _result_ be ToBoolean( ? Call(_fn_, *undefined*, &laquo; _func_ &raquo;)).
+      1. Return _result_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-invokedirectevalhook" aoid="InvokeDirectEvalHook">
+    <h1>InvokeDirectEvalHook ( _realmRec_, _x_ )</h1>
+
+    <p>The abstract operation InvokeDirectEvalHook with arguments _realmRec_ and _x_ performs the following steps:</p>
+
+    <emu-alg>
+    1. Assert: realm is a Realm Record.
+    1. Let _fn_ be _realmRec_.[[EvalHook]].
+    1. If _fn_ is *undefined*, return _x_.
+    1. Assert: IsCallable(_fn_) is *true*.
+    1. Return ? Call(_fn_, *undefined*, « _x_ »).
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-invokeimporthook" aoid="InvokeImportHook">
+    <h1>InvokeImportHook ( _realmRec_, _referencingScriptOrModule_, _specifierString_, _promiseCapability_ )</h1>
+
+    <p>The abstract operation InvokeImportHook with arguments _realmRec_, _referencingScriptOrModule_, _specifier_ and _promiseCapability_ performs the following steps:</p>
+
+    <emu-alg>
+    1. Assert: _realmRec_ is a Realm Record.
+    1. Assert: Type(_specifierString_) is String.
+    1. Assert: _referencingScriptOrModule_ is a Script Record or Module Record (i.e. is not null).
+    1. Assert: _resultCapability_ is a PromiseCapability Record.
+    1. Let _fn_ be _realmRec_.[[ImportHook]].
+    1. If _fn_ is *undefined*, then
+      1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, _promiseCapability_).
+    1. Assert: IsCallable(_fn_) is *true*.
+    1. If _referencingScriptOrModule_ is a Module Record, then
+      1. Assert: ModuleEvaluation has already been invoked on _referencingScriptOrModule_ and successfully completed.
+      1. Let _referrer_ be GetModuleNamespace(_referencingScriptOrModule_).
+      1. IfAbruptRejectPromise(_referrer_, _promiseCapability_).
+    1. Else,
+      1. Let _referrer_ be *null*.
+    1. Let _value_ be Call(_fn_, *undefined*, « _referrer_, _specifier_ »).
+    1. IfAbruptRejectPromise(_value_, _promiseCapability_).
+    1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _value_ »).
+    </emu-alg>
+  </emu-clause>
+
+</emu-clause>
 
 <!-- es6num="15.2.1.16.1" -->
 <emu-clause id="sec-parsemodule" aoid="ParseModule">
@@ -161,36 +220,57 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
   <emu-alg>
     1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
     1. <ins>If _direct_ is *true*, then</ins>
-      1. <ins>Let _xValue_ be ? InvokeEvalHook(_x_, _evalRealm_).</ins>
+      1. <ins>Let _xValue_ be ? InvokeDirectEvalHook(_x_, _evalRealm_).</ins>
     1. If Type(_xValue_) is not String, return _xValue_.
     1. ...
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-import-calls">
-  <h1><ins>Import Calls</ins></h1>
 
-  <emu-clause id="sec-import-call-runtime-semantics-evaluation">
-    <h1>Runtime Semantics: Evaluation</h1>
+<!-- es6num="12.3.4.1" -->
+<emu-clause id="sec-function-calls-runtime-semantics-evaluation">
+  <h1>Runtime Semantics: Evaluation</h1>
+  <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
+  <emu-alg>
+    1. Let _expr_ be CoveredCallExpression of |CoverCallExpressionAndAsyncArrowHead|.
+    1. Let _memberExpr_ be the |MemberExpression| of _expr_.
+    1. Let _arguments_ be the |Arguments| of _expr_.
+    1. Let _ref_ be the result of evaluating _memberExpr_.
+    1. Let _func_ be ? GetValue(_ref_).
+    1. If Type(_ref_) is Reference and IsPropertyReference(_ref_) is *false* and GetReferencedName(_ref_) is `"eval"`, then
+      1. <ins>Let _evalRealm_ be the current Realm Record</ins>.
+      1. <ins>Let _isDirectEval_ be ? InvokeIsDirectEvalHook(_evalRealm_, _func_)</ins>.
+      1. If <ins>_isDirectEval_</ins><del>SameValue(_func_, %eval%)</del> is *true*, then
+        1. Let _argList_ be ? ArgumentListEvaluation(_arguments_).
+        1. If _argList_ has no elements, return *undefined*.
+        1. Let _evalText_ be the first element of _argList_.
+        1. If the source code matching this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
+        1. <del>Let _evalRealm_ be the current Realm Record</del>.
+        1. Perform ? HostEnsureCanCompileStrings(_evalRealm_, _evalRealm_).
+        1. Return ? PerformEval(_evalText_, _evalRealm_, _strictCaller_, *true*).
+    1. ...
+  </emu-alg>
+  ...
+</emu-clause>
 
-    <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
-    <emu-alg>
-    1. Let _referencingScriptOrModule_ be ! GetActiveScriptOrModule().
-    1. Assert: _referencingScriptOrModule_ is a Script Record or Module Record (i.e. is not *null*).
-    1. Let _argRef_ be the result of evaluating |AssignmentExpression|.
-    1. Let _specifier_ be ? GetValue(_argRef_).
-    1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-    1. Let _specifierString_ be ToString(_specifier_).
-    1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-    1. <ins>Let _ctx_ be the running execution context</ins>.
-    1. <ins>Let _currentRealm_ be ctx's Realm</ins>.
-    1. <ins>If _currentRealm_.[[IsUserCreated]] is *true*, then</ins>
-      1. <ins>Return ? InvokeImportHook(_referencingScriptOrModule_, _specifierString_).</ins>
-    1. <ins>Else,</ins>
-      1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, _promiseCapability_).
-    1. Return _promiseCapability_.[[Promise]].
-    </emu-alg>
-  </emu-clause>
+<emu-clause id="sec-import-call-runtime-semantics-evaluation">
+  <h1>Runtime Semantics: Evaluation</h1>
+
+  <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
+  <emu-alg>
+  1. Let _referencingScriptOrModule_ be ! GetActiveScriptOrModule().
+  1. Assert: _referencingScriptOrModule_ is a Script Record or Module Record (i.e. is not *null*).
+  1. Let _argRef_ be the result of evaluating |AssignmentExpression|.
+  1. Let _specifier_ be ? GetValue(_argRef_).
+  1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+  1. Let _specifierString_ be ToString(_specifier_).
+  1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
+  1. <ins>Let _ctx_ be the running execution context</ins>.
+  1. <ins>Let _currentRealm_ be ctx's Realm</ins>.
+  1. <ins>Perform ! InvokeImportHook(_currentRealm_, _referencingScriptOrModule_, _specifierString_, _promiseCapability_)</ins>.
+  1. <del>Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, _promiseCapability_)</del>.
+  1. Return _promiseCapability_.[[Promise]].
+  </emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-realm-objects">
@@ -198,48 +278,28 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
 
     <emu-clause id="sec-realm-abstract-operations">
         <h1>Realm Abstract Operations</h1>
-
-        <emu-clause id="sec-invokeevalhook" aoid="InvokeEvalHook">
-            <h1>InvokeEvalHook ( _realmRec_, _x_ )</h1>
-
-            <p>The abstract operation InvokeEvalHook with arguments _realmRec_ and _x_ performs the following steps:</p>
-
-            <emu-alg>
-            1. Assert: realm is a Realm Record.
-            1. Let _fn_ be _realmRec_.[[EvalHook]].
-            1. If _fn_ is *undefined*, return _x_.
-            1. Assert: IsCallable(_fn_) is *true*.
-            1. Return ? Call(_fn_, *undefined*, « _x_ »).
-            </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-invokeimporthook" aoid="InvokeImportHook">
-            <h1>InvokeImportHook ( _realmRec_, _referencingScriptOrModule_, _specifier_ )</h1>
-
-            <p>The abstract operation InvokeImportHook with arguments _realmRec_, _referencingScriptOrModule_, and _specifier_ performs the following steps:</p>
-
-            <emu-alg>
-            1. Assert: _realmRec_ is a Realm Record.
-            1. Assert: Type(_specifier_) is String.
-            1. Assert: _referencingScriptOrModule_ is a Script Record or Module Record (i.e. is not null).
-            1. Let _fn_ be _realmRec_.[[ImportHook]].
-            1. If _fn_ is *undefined*, then
-              1. Return a promise rejected with a new *TypeError* exception.
-            1. If _referencingScriptOrModule_ is a Module Record, then
-              1. Assert: ModuleEvaluation has already been invoked on _referencingScriptOrModule_ and successfully completed.
-              1. Let _ns_ be GetModuleNamespace(_referencingScriptOrModule_).
-              1. If _ns_ is an abrupt completion, return a promise rejected with _namespace_.[[Value]].
-            1. Else,
-              1. Let _ns_ be *null*.
-            1. Let _p_ be Call(_fn_, *undefined*, « _ns_, _specifier_ »).
-            1. If _p_ is an abrupt completion, then
-              1. return a promise rejected with _p_.[[Value]].
-            1. Else,
-              1. If _p_ is a Completion Record, return _p_.[[Value]].
-            </emu-alg>
-        </emu-clause>
-
     </emu-clause>
+
+    <emu-clause id="sec-realm-built-in-function-objects">
+      <h1>Built-in Function Objects</h1>
+
+      <emu-clause id="sec-realm-default-import-hook-functions">
+        <h1>Realm Default Import Hook Functions</h1>
+
+        <p>A Realm default import hook function is an anonymous built-in function.</p>
+
+        <p>When aRealm default import hook function is called with arguments _referrer_ and _specifier_, the following steps are taken:</p>
+
+        <emu-alg>
+          1. Throw a new *TypeError*.
+        </emu-alg>
+
+        <emu-note>
+          By default, newly created realms do not expose host specific behavior when evaluating _import()_ calls.
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+
 
     <emu-clause id="sec-the-realm-constructor">
         <h1>The Realm Constructor</h1>
@@ -264,8 +324,10 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
               1. Let _opts_ be ? ToObject(_options_).
               1. Let _importHook_ be ? Get(_opts_, "importHook").
               1. If _importHook_ is not *undefined* and IsCallable(_importHook_) is *false*, throw a TypeError exception.
-              1. Let _evalHook_ be ? Get(_opts_, "importHook").
+              1. Let _evalHook_ be ? Get(_opts_, "evalHook").
               1. If _evalHook_ is not *undefined* and IsCallable(_evalHook_) is *false*, throw a TypeError exception.
+              1. Let _isDirectEvalHook_ be ? Get(_opts_, "isDirectEvalHook").
+              1. If _isDirectEvalHook_ is not *undefined* and IsCallable(_isDirectEvalHook_) is *false*, throw a TypeError exception.
               1. Let _thisValue_ be ? Get(_opts_, "thisValue").
               1. If _thisValue_ is not *undefined* and Type(_thisValue_) is not Object, throw a TypeError exception.
               1. Let _globalObj_ be ? Get(_opts_, "global").
@@ -273,11 +335,13 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
             1. Let _realmRec_ be CreateRealm().
             1. Set _O_.[[Realm]] to _realmRec_.
             1. Perform ? SetRealmGlobalObject(_realmRec_, _globalObj_, _thisValue_).
-            1. Set _realmRec_.[[IsUserCreated]] to *true*.
+            1. If _importHook_ is *undefined*, then
+              1. Let _importHook_ be a new built-in function object as defined in <emu-xref href="#sec-realm-default-import-hook-functions"></emu-xref>.
+            1. Set _realmRec_.[[ImportHook]] to _importHook_.
             1. If _evalHook_ is not *undefined*, then
-              1. Set _realmRec_.[[directEval]] to _evalHook_.
-            1. If _importHook_ is not *undefined*, then
-              1. Set _realmRec_.[[directImport]] to _importHook_.
+              1. Set _realmRec_.[[EvalHook]] to _evalHook_.
+            1. If _isDirectEvalHook_ is not *undefined*, then
+              1. Set _realmRec_.[[IsDirectEvalHook]] to _isDirectEvalHook_.
             1. Let _init_ be ? GetMethod(_O_, *"init"*).
             1. If IsCallable(_init_) is not *true*, throw a *TypeError* exception.
             1. Perform ? Call(_init_, _O_).

--- a/spec/index.emu
+++ b/spec/index.emu
@@ -83,6 +83,94 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
     </table>
 </emu-table>
 
+<!-- es6num="15.2.1.16.1" -->
+<emu-clause id="sec-parsemodule" aoid="ParseModule">
+    <h1>ParseModule ( _sourceText_, _realm_, _hostDefined_ )</h1>
+    <emu-alg>
+    1. ...
+    1. Let _exportEntries_ be ExportEntries of _body_.
+    1. <ins>Let _resolvedModules_ be a new empty List</ins>.
+    1. For each ExportEntry Record _ee_ in _exportEntries_, do
+        1. ...
+    1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[HostDefined]]: _hostDefined_, [[Namespace]]: *undefined*, [[Evaluated]]: *false*, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_<ins>, [[ResolvedModules]]: _resolvedModules_</ins>}.
+    </emu-alg>
+</emu-clause>
+
+<emu-clause id="sec-resolvemodule" aoid="ResolveModule">
+    <h1>ResolveModule ( _referencingModule_, _specifier_ )</h1>
+    <p>The abstract operation ResolveModule with arguments _referencingModule_ and _specifier_ resolves the concrete Module Record subclass instance that corresponds to the ModuleSpecifier String, _specifier_, occurring within the context of the module represented by the Source Text Module Record _referencingModule_. ResolveModule performs the following steps:</p>
+    <emu-alg>
+    1. Assert: _referencingModule_ is a Source Text Module Record.
+    1. Assert: Type(_specifier_) is String.
+    1. Let _resolvedModules_ be _referencingModule_.[[ResolvedModules]].
+    1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _requiredModule_,
+      1. If _p_.[[Key]] is is equal _specifier_, then
+        1. Return _p_.[[Value]].
+    1. Let _requiredModule_ be ? HostResolveImportedModule(_referencingModule_, _specifier_).
+    1. Append _requiredModule_ as the last element of _resolvedModules_.
+    1. Return _requiredModule_.
+</emu-clause>
+
+<!-- es6num="15.2.1.16.5" -->
+<emu-clause id="sec-moduleevaluation">
+    <h1>ModuleEvaluation( ) Concrete Method</h1>
+    <emu-alg>
+    1. ...
+    6. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+        1. Let _requiredModule_ be ! <del>HostResolveImportedModule</del><ins>ResolveModule</ins>(_module_, _required_).
+        1. ...
+    1. ...
+    </emu-alg>
+</emu-clause>
+
+
+<!-- es6num="15.2.1.16.2" -->
+<emu-clause id="sec-getexportednames">
+    <h1>GetExportedNames( _exportStarSet_ ) Concrete Method</h1>
+    <emu-alg>
+        1. ...
+        14. Let _requestedModule_ be ? <del>HostResolveImportedModule</del><ins>ResolveModule</ins>(_module_, _e_.[[ModuleRequest]]).
+        1. ...
+    </emu-alg>
+</emu-clause>
+
+
+<!-- es6num="15.2.1.16.3" -->
+<emu-clause id="sec-resolveexport">
+    <h1>ResolveExport( _exportName_, _resolveSet_ ) Concrete Method</h1>
+    <emu-alg>
+    1. ...
+    4. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
+        1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
+        1. Assert: _module_ imports a specific binding for this export.
+        1. Let _importedModule_ be ? <del>HostResolveImportedModule</del><ins>ResolveModule</ins>(_module_, _e_.[[ModuleRequest]]).
+        1. ...
+    1. ...
+    7. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
+        1. Let _importedModule_ be ? <del>HostResolveImportedModule</del><ins>ResolveModule</ins>(_module_, _e_.[[ModuleRequest]]).
+        ...
+    1. ...
+    </emu-alg>
+</emu-clause>
+
+<!-- es6num="15.2.1.16.4" -->
+<emu-clause id="sec-moduledeclarationinstantiation">
+    <h1>ModuleDeclarationInstantiation( ) Concrete Method</h1>
+    <emu-alg>
+    1. ...
+    8. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+        1. NOTE: Before instantiating a module, all of the modules it requested must be available. An implementation may perform this test at any time prior to this point.
+        1. Let _requiredModule_ be ? <del>HostResolveImportedModule</del><ins>ResolveModule</ins>(_module_, _required_).
+        1. ...
+    1. ...
+    12. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
+        1. Let _importedModule_ be ! <del>HostResolveImportedModule</del><ins>ResolveModule</ins>(_module_, _in_.[[ModuleRequest]]).
+        1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
+        1. ...
+    1. ...
+    </emu-alg>
+</emu-clause>
+
 <!-- es6num="18.2.1.1" -->
 <emu-clause id="sec-performeval" aoid="PerformEval">
   <h1>Runtime Semantics: PerformEval( _x_, _evalRealm_, _strictCaller_, _direct_ )</h1>

--- a/spec/index.emu
+++ b/spec/index.emu
@@ -268,7 +268,7 @@ location: https://rawgit.com/caridy/proposal-realms/master/index.html
               1. If _evalHook_ is not *undefined* and IsCallable(_evalHook_) is *false*, throw a TypeError exception.
               1. Let _thisValue_ be ? Get(_opts_, "thisValue").
               1. If _thisValue_ is not *undefined* and Type(_thisValue_) is not Object, throw a TypeError exception.
-              1. Let _globalObj_ be ? Get(_opts_, "globalObj").
+              1. Let _globalObj_ be ? Get(_opts_, "global").
               1. If _globalObj_ is not *undefined* and Type(_globalObj_) is not Object, throw a TypeError exception.
             1. Let _realmRec_ be CreateRealm().
             1. Set _O_.[[Realm]] to _realmRec_.


### PR DESCRIPTION
* Adding caching mechanism for dependencies (to support pre-populating the dependencies of a module record in the future). #49
* hooks are now options in constructor instead of global symbols. #41, #39
* `global` and `thisValue` can be provided via options, and are created otherwise. #42
* consolidating `directEval` and `indirectEval` into `evalHook` option #17 #12
* introduce `importHook` #46
* preliminar work to interact with the `import()` mechanism.
* adding a new getter for `thisValue` to have symmetry with `global`.

### New API

```js
const r = new Realm({
    global: undefined, // or any arbitrary object
    thisValue: undefined, // or any arbitrary object
    evalHook(sourceText) {
         return sourceText; 
    },
    importHook(referrerNamespace, specifierString) {
         /* until we spec the reflective API for dynamic and source text module records */ 
         return Promise.resolve(ns); 
    }
});
r.eval(`1 + 1`); // yields 2
r.eval(`import('foo')`); // yields a promise of the corresponding Namespace object or throw if no hook is defined
```