### PR TITLE
realm.js: don't freeze globals

### DIFF
--- a/shim/src/realm.js
+++ b/shim/src/realm.js
@@ -130,6 +130,14 @@ function createEvaluators(realmRec) {
 function setDefaultBindings(realmRec) {
   const intrinsics = realmRec[Intrinsics];
   const descs = getStdLib(intrinsics);
+  for (const name of Object.getOwnPropertyNames(descs)) {
+    // these three properties should be immutable
+    if (name !== 'Infinity' && name !== 'NaN' && name !== 'undefined') {
+      // everything else should be mutable
+      descs[name].writable = true;
+      descs[name].configurable = true;
+    }
+  }
   defineProperties(realmRec[GlobalObject], descs);
 }
 

--- a/shim/src/realm.js
+++ b/shim/src/realm.js
@@ -130,14 +130,6 @@ function createEvaluators(realmRec) {
 function setDefaultBindings(realmRec) {
   const intrinsics = realmRec[Intrinsics];
   const descs = getStdLib(intrinsics);
-  for (const name of Object.getOwnPropertyNames(descs)) {
-    // these three properties should be immutable
-    if (name !== 'Infinity' && name !== 'NaN' && name !== 'undefined') {
-      // everything else should be mutable
-      descs[name].writable = true;
-      descs[name].configurable = true;
-    }
-  }
   defineProperties(realmRec[GlobalObject], descs);
 }
 

--- a/shim/src/stdlib.js
+++ b/shim/src/stdlib.js
@@ -1,84 +1,100 @@
 export function getStdLib(intrinsics) {
-  const i = intrinsics;
-
-  return {
+  const descriptors = {
     // *** 18.1 Value Properties of the Global Object
 
     Infinity: { value: Infinity },
     NaN: { value: NaN },
-    undefined: { value: undefined },
+    undefined: { value: undefined }
+  };
 
+  // All the following stdlib items have the same name on both our intrinsics
+  // object and on the global object. Unlike Infinity/NaN/undefined, these
+  // should all be writable and configurable.
+  const names = [
     // *** 18.2 Function Properties of the Global Object
 
-    // Make eval writable to allow proxy to return a different
-    // value, and leave it non-unconfigurable to prevent userland
-    // from changing its descriptor and breaking an invariant.
-    eval: { value: i.eval, writable: true },
-    isFinite: { value: i.isFinite },
-    isNaN: { value: i.isNaN },
-    parseFloat: { value: i.parseFloat },
-    parseInt: { value: i.parseInt },
+    'eval',
+    'isFinite',
+    'isNaN',
+    'parseFloat',
+    'parseInt',
 
-    decodeURI: { value: i.decodeURI },
-    decodeURIComponent: { value: i.decodeURIComponent },
-    encodeURI: { value: i.encodeURI },
-    encodeURIComponent: { value: i.encodeURIComponent },
+    'decodeURI',
+    'decodeURIComponent',
+    'encodeURI',
+    'encodeURIComponent',
 
     // *** 18.3 Constructor Properties of the Global Object
 
-    Array: { value: i.Array },
-    ArrayBuffer: { value: i.ArrayBuffer },
-    Boolean: { value: i.Boolean },
-    DataView: { value: i.DataView },
-    Date: { value: i.Date },
-    Error: { value: i.Error },
-    EvalError: { value: i.EvalError },
-    Float32Array: { value: i.Float32Array },
-    Float64Array: { value: i.Float64Array },
-    Function: { value: i.Function },
-    Int8Array: { value: i.Int8Array },
-    Int16Array: { value: i.Int16Array },
-    Int32Array: { value: i.Int32Array },
-    Map: { value: i.Map },
-    Number: { value: i.Number },
-    Object: { value: i.Object },
-    Promise: { value: i.Promise },
-    Proxy: { value: i.Proxy },
-    RangeError: { value: i.RangeError },
-    ReferenceError: { value: i.ReferenceError },
-    RegExp: { value: i.RegExp },
-    Set: { value: i.Set },
-    // SharedArrayBuffer // Deprecated on Jan 5, 2018
-    String: { value: i.String },
-    Symbol: { value: i.Symbol },
-    SyntaxError: { value: i.SyntaxError },
-    TypeError: { value: i.TypeError },
-    Uint8Array: { value: i.Uint8Array },
-    Uint8ClampedArray: { value: i.Uint8ClampedArray },
-    Uint16Array: { value: i.Uint16Array },
-    Uint32Array: { value: i.Uint32Array },
-    URIError: { value: i.URIError },
-    WeakMap: { value: i.WeakMap },
-    WeakSet: { value: i.WeakSet },
+    'Array',
+    'ArrayBuffer',
+    'Boolean',
+    'DataView',
+    'Date',
+    'Error',
+    'EvalError',
+    'Float32Array',
+    'Float64Array',
+    'Function',
+    'Int8Array',
+    'Int16Array',
+    'Int32Array',
+    'Map',
+    'Number',
+    'Object',
+    'Promise',
+    'Proxy',
+    'RangeError',
+    'ReferenceError',
+    'RegExp',
+    'Set',
+    // 'SharedArrayBuffer' // Deprecated on Jan 5, 2018
+    'String',
+    'Symbol',
+    'SyntaxError',
+    'TypeError',
+    'Uint8Array',
+    'Uint8ClampedArray',
+    'Uint16Array',
+    'Uint32Array',
+    'URIError',
+    'WeakMap',
+    'WeakSet',
 
     // *** 18.4 Other Properties of the Global Object
 
-    // Atomics: { value: i.Atomics }, // Deprecated on Jan 5, 2018
-    JSON: { value: i.JSON },
-    Math: { value: i.Math },
-    Reflect: { value: i.Reflect },
+    // 'Atomics', // Deprecated on Jan 5, 2018
+    'JSON',
+    'Math',
+    'Reflect',
 
     // *** Annex B
 
-    escape: { value: i.escape },
-    unescape: { value: i.unescape },
+    'escape',
+    'unescape',
 
     // *** ECMA-402
 
-    Intl: { value: i.Intl },
+    'Intl',
 
     // *** ESNext
 
-    Realm: { value: i.Realm }
-  };
+    'Realm'
+  ];
+
+  for (const name of names) {
+    descriptors[name] = {
+      value: intrinsics[name],
+      writable: true,
+      configurable: true
+    };
+  }
+
+  // TODO: we changed eval to be configurable along with everything else,
+  // should we change it back to honor this earlier comment?
+  // // Make eval writable to allow proxy to return a different
+  // // value, and leave it non-unconfigurable to prevent userland
+  // // from changing its descriptor and breaking an invariant.
+
+  return descriptors;
 }

--- a/shim/src/stdlib.js
+++ b/shim/src/stdlib.js
@@ -96,5 +96,10 @@ export function getStdLib(intrinsics) {
   // // value, and leave it non-unconfigurable to prevent userland
   // // from changing its descriptor and breaking an invariant.
 
+  // (note: 'non-unconfigurable' should have been 'non-configurable')
+
+  // we need to prevent the user from manipulating the 'eval' binding while
+  // simultaneously enabling the proxy to *switch* the 'eval' binding
+
   return descriptors;
 }

--- a/shim/test/realm/mutable.js
+++ b/shim/test/realm/mutable.js
@@ -1,0 +1,30 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+
+test('most Realm globals are mutable', t => {
+  t.plan(3);
+  const r = new Realm();
+
+  r.evaluate('decodeURI = function(uri) { return "decoded" }');
+  t.equal(r.evaluate('decodeURI("http://example.org/")'), 'decoded');
+
+  r.evaluate('Math.embiggen = function(a) { return a+1 }');
+  t.equal(r.evaluate('Math.embiggen(1)'), 2);
+
+  r.evaluate('Realm = function(opts) { this.extra = "extra" }');
+  t.equal(r.evaluate('(new Realm({})).extra'), 'extra');
+});
+
+test('some Realm globals are immutable', t => {
+  t.plan(6);
+  const r = new Realm();
+
+  t.throws(() => r.evaluate('Infinity = 4'), r.global.TypeError); // strict mode
+  t.equal(r.evaluate('Infinity'), Infinity);
+
+  t.throws(() => r.evaluate('NaN = 4'), r.global.TypeError);
+  t.notEqual(r.evaluate('NaN'), 4);
+
+  t.throws(() => r.evaluate('undefined = 4'), r.global.TypeError);
+  t.equal(r.evaluate('undefined'), undefined);
+});


### PR DESCRIPTION
The spec says the initial Realm state should have writable+configurable
global properties (except for three).

We'll want this to happen for frozen/SES realms, eventually, but not here. We
need to be able to run a shim that replaces Realm, or others.