### PR TITLE
fix detection of environments that don't support 'function*'

### DIFF
--- a/shim/src/functions.js
+++ b/shim/src/functions.js
@@ -14,13 +14,13 @@ import { defineProperty, defineProperties, getPrototypeOf, setPrototypeOf } from
  * 5. Replace its [[Prototype]] slot with the noop constructor of Function
  */
 function repairFunction(contextRec, functionName, functionDecl) {
-  const { contextEval, contextFunction } = contextRec;
+  const { contextEval, contextFunction, contextGlobal } = contextRec;
 
   let FunctionInstance;
   try {
     FunctionInstance = contextEval(`(${functionDecl}(){})`);
   } catch (e) {
-    if (!(e instanceof SyntaxError)) {
+    if (!(e instanceof contextGlobal.SyntaxError)) {
       // Re-throw
       throw e;
     }

--- a/shim/src/intrinsics.js
+++ b/shim/src/intrinsics.js
@@ -28,7 +28,7 @@ export function getIntrinsics(contextRec) {
   try {
     GeneratorFunctionInstance = g.eval('(function*(){})');
   } catch (e) {
-    if (!(e instanceof SyntaxError)) {
+    if (!(e instanceof g.SyntaxError)) {
       // Re-throw
       throw e;
     }
@@ -42,7 +42,7 @@ export function getIntrinsics(contextRec) {
   try {
     AsyncGeneratorFunctionInstance = g.eval('(async function*(){})');
   } catch (e) {
-    if (!(e instanceof SyntaxError)) {
+    if (!(e instanceof g.SyntaxError)) {
       // Re-throw
       throw e;
     }


### PR DESCRIPTION
repairFunction and getIntrinsics test the environment for 'function*' support
by evaluating a string and checking for a SyntaxError, however the identity
discontinuity between the outer Realm's "SyntaxError" and the inner Realm's
distinct "SyntaxError" objects broke those tests. I changed them to compare
against the inner Realm's "SyntaxError".

fixes #105