### PR TITLE
shim: don't leak primordials through Error objects

### DIFF
--- a/shim/test/realm/leak-error.js
+++ b/shim/test/realm/leak-error.js
@@ -1,0 +1,83 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+
+test('constructor error should not leak TypeError', t => {
+  const r = new Realm();
+  function check() {
+    try {
+      const r2 = new Realm({ intrinsics: 'bad values cause TypeError' });
+      r2.evaluate('1'); // should never reach here
+      return false;
+    } catch (e) {
+      return e;
+    }
+  }
+  r.evaluate(`this.check = ${check};`);
+  const e = r.evaluate('check();');
+  t.notEqual(e, false, 'new Realm should have failed but did not');
+  t.notOk(e instanceof TypeError, "should not be parent's TypeError");
+  t.ok(e instanceof r.global.TypeError);
+
+  // we're specifically concerned about this sort of attack: this should
+  // modify the child Realm's TypeError.prototype, not ours
+  r.evaluate('check().__proto__.i_was_here = 5;');
+  t.equal(TypeError.prototype.i_was_here, undefined);
+  t.end();
+});
+
+test('init() with bad this should not leak TypeError', t => {
+  const r = new Realm();
+  function check() {
+    const r2 = new Realm();
+    try {
+      r2.init.apply(4); // causes TypeError in init(), typeof O !== 'object'
+      return false;
+    } catch (e) {
+      return e;
+    }
+  }
+  r.evaluate(`this.check = ${check};`);
+  const e = r.evaluate('check();');
+  t.notEqual(e, false, 'new Realm should have failed but did not');
+  t.notOk(e instanceof TypeError, "should not be parent's TypeError");
+  t.ok(e instanceof r.global.TypeError);
+  t.end();
+});
+
+test('init() with bad this should not leak TypeError', t => {
+  const r = new Realm();
+  function check() {
+    const r2 = new Realm();
+    try {
+      r2.init.apply({}); // causes TypeError in init(), Realm2RealmRec.has(O)
+      return false;
+    } catch (e) {
+      return e;
+    }
+  }
+  r.evaluate(`this.check = ${check};`);
+  const e = r.evaluate('check();');
+  t.notEqual(e, false, 'new Realm should have failed but did not');
+  t.notOk(e instanceof TypeError, "should not be parent's TypeError");
+  t.ok(e instanceof r.global.TypeError);
+  t.end();
+});
+
+test('eval() with non-parsable string should not leak SyntaxError', t => {
+  const r = new Realm();
+  function check() {
+    const r2 = new Realm();
+    try {
+      r2.evaluate('!$%$%!@#$%!#@$%'); // non-parsable, should cause error
+      return false;
+    } catch (e) {
+      return e;
+    }
+  }
+  r.evaluate(`this.check = ${check};`);
+  const e = r.evaluate('check();');
+  t.notEqual(e, false, 'new Realm should have failed but did not');
+  t.notOk(e instanceof SyntaxError, "should not be parent's SyntaxError");
+  t.ok(e instanceof r.global.SyntaxError);
+  t.end();
+});


### PR DESCRIPTION
@erights and I noticed that errors thrown during `new Realm` in a child will reveal an Error object that comes from the top-level environment, from which the child could get access to primordials that we're trying to protect. This wraps those cases with a function that rewrites the Error objects to use the local Realm's `Error` instead.
