### PR TITLE
shim: Fix function-injection attack and rename evaluators for clarity

### DIFF
--- a/shim/src/context.js
+++ b/shim/src/context.js
@@ -1,4 +1,4 @@
-import { getDirectEvalEvaluatorFactory } from './evaluators';
+import { getScopedEvaluatorFactory } from './evaluators';
 import { sanitize } from './sanitize';
 
 // Detection used in RollupJS.
@@ -43,7 +43,7 @@ export function createContextRec(context) {
 
   // Create the evaluator factory that will generate the evaluators
   // for each compartment realm.
-  contextRec.evalEvaluatorFactory = getDirectEvalEvaluatorFactory(contextRec);
+  contextRec.scopedEvaluatorFactory = getScopedEvaluatorFactory(contextRec);
 
   sanitize(contextRec);
   return contextRec;

--- a/shim/src/evaluators.js
+++ b/shim/src/evaluators.js
@@ -57,7 +57,7 @@ export function getDirectEvalEvaluator(realmRec) {
   }.eval;
 
   // Ensure that eval from any compartment in a root realm is an
-  // instance of Function in any compartment of the same root ralm.
+  // instance of Function in any compartment of the same root realm.
   const { contextGlobal, contextFunction } = contextRec;
   setPrototypeOf(evaluator, contextFunction.prototype.constructor);
 

--- a/shim/src/evaluators.js
+++ b/shim/src/evaluators.js
@@ -82,9 +82,6 @@ export function getFunctionEvaluator(realmRec) {
   const evaluator = function Function(...params) {
     const functionBody = `${params.pop()}` || '';
     let functionParams = `${params.join(',')}`;
-    // todo: can the Function constructor syntax accept complex parameters
-    // (default values, spread args, destructuring patterns)? Our new
-    // Function here cannot.
 
     // Is this a real functionBody, or is someone attempting an injection
     // attack? This will throw a SyntaxError if the string is not actually a

--- a/shim/src/evaluators.js
+++ b/shim/src/evaluators.js
@@ -81,7 +81,10 @@ export function getFunctionEvaluator(realmRec) {
 
   const evaluator = function Function(...params) {
     const functionBody = `${params.pop()}` || '';
-    let functionParams = params.join(',');
+    let functionParams = `${params.join(',')}`;
+    // todo: can the Function constructor syntax accept complex parameters
+    // (default values, spread args, destructuring patterns)? Our new
+    // Function here cannot.
 
     // Is this a real functionBody, or is someone attempting an injection
     // attack? This will throw a SyntaxError if the string is not actually a

--- a/shim/src/evaluators.js
+++ b/shim/src/evaluators.js
@@ -44,8 +44,10 @@ export function getSafeEvaluator(realmRec) {
 
   const scopedEvaluator = contextRec.scopedEvaluatorFactory(proxy);
 
-  // Create an eval without a [[Construct]] behavior such that the
-  // invocation "new eval()" throws TypeError: eval is not a constructor".
+  // We use the the concise method syntax to create an eval without a
+  // [[Construct]] behavior (such that the invocation "new eval()" throws
+  // TypeError: eval is not a constructor"), but which still accepts a 'this'
+  // binding.
   const evaluator = {
     eval(src) {
       handler.useUnsafeEvaluator = true;
@@ -53,6 +55,8 @@ export function getSafeEvaluator(realmRec) {
         // Ensure that "this" resolves to the secure global.
         return scopedEvaluator.call(globalObject, src);
       } finally {
+        // belt and suspenders: the proxy switches this off immediately after
+        // the first access, but just in case we clear it here too
         handler.useUnsafeEvaluator = false;
       }
     }

--- a/shim/src/handler.js
+++ b/shim/src/handler.js
@@ -3,21 +3,20 @@ export class Handler {
   // are not available from the proxy.
 
   constructor(contextRec) {
-    const { contextGlobal } = contextRec;
-    this.contextGlobal = contextGlobal;
+    this.unsafeEval = contextRec.contextGlobal.eval;
 
     // this flag allow us to determine if the eval() call is a controlled
     // eval done by the realm's code or if it is user-land invocation, so
     // we can react differently.
-    this.isInternalEvaluation = false;
+    this.useUnsafeEvaluator = false;
   }
 
   get(target, prop) {
     // Special treatment for eval.
     if (prop === 'eval') {
-      if (this.isInternalEvaluation) {
-        this.isInternalEvaluation = false;
-        return this.contextGlobal.eval;
+      if (this.useUnsafeEvaluator) {
+        this.useUnsafeEvaluator = false;
+        return this.unsafeEval;
       }
       return target.eval;
     }

--- a/shim/src/handler.js
+++ b/shim/src/handler.js
@@ -3,6 +3,7 @@ export class Handler {
   // are not available from the proxy.
 
   constructor(contextRec) {
+    this.contextGlobal = contextRec.contextGlobal;
     this.unsafeEval = contextRec.contextGlobal.eval;
 
     // this flag allow us to determine if the eval() call is a controlled

--- a/shim/src/realm.js
+++ b/shim/src/realm.js
@@ -130,6 +130,14 @@ function createEvaluators(realmRec) {
 function setDefaultBindings(realmRec) {
   const intrinsics = realmRec[Intrinsics];
   const descs = getStdLib(intrinsics);
+  for (const name of Object.getOwnPropertyNames(descs)) {
+    // these three properties should be immutable
+    if (name !== 'Infinity' && name !== 'NaN' && name !== 'undefined') {
+      // everything else should be mutable
+      descs[name].writable = true;
+      descs[name].configurable = true;
+    }
+  }
   defineProperties(realmRec[GlobalObject], descs);
 }
 

--- a/shim/src/realm.js
+++ b/shim/src/realm.js
@@ -130,14 +130,6 @@ function createEvaluators(realmRec) {
 function setDefaultBindings(realmRec) {
   const intrinsics = realmRec[Intrinsics];
   const descs = getStdLib(intrinsics);
-  for (const name of Object.getOwnPropertyNames(descs)) {
-    // these three properties should be immutable
-    if (name !== 'Infinity' && name !== 'NaN' && name !== 'undefined') {
-      // everything else should be mutable
-      descs[name].writable = true;
-      descs[name].configurable = true;
-    }
-  }
   defineProperties(realmRec[GlobalObject], descs);
 }
 

--- a/shim/src/stdlib.js
+++ b/shim/src/stdlib.js
@@ -93,10 +93,8 @@ export function getStdLib(intrinsics) {
   // TODO: we changed eval to be configurable along with everything else,
   // should we change it back to honor this earlier comment?
   // // Make eval writable to allow proxy to return a different
-  // // value, and leave it non-unconfigurable to prevent userland
+  // // value, and leave it non-configurable to prevent userland
   // // from changing its descriptor and breaking an invariant.
-
-  // (note: 'non-unconfigurable' should have been 'non-configurable')
 
   // we need to prevent the user from manipulating the 'eval' binding while
   // simultaneously enabling the proxy to *switch* the 'eval' binding

--- a/shim/src/symbols.js
+++ b/shim/src/symbols.js
@@ -1,4 +1,4 @@
 export const Intrinsics = Symbol('Intrinsics Slot');
 export const GlobalObject = Symbol('GlobalObject Slot');
-export const IsDirectEvalTrap = Symbol('IsDirectEvalTrap Slot');
+export const SafeEvaluator = Symbol('SafeEvaluator Slot');
 export const ContextRec = Symbol('Shim Context');

--- a/shim/test/realm/function-eval.js
+++ b/shim/test/realm/function-eval.js
@@ -21,3 +21,27 @@ test('function-injection', t => {
 
   t.end();
 });
+
+test('function-default-parameters', t => {
+  const goodFunc = 'return a+1';
+  const r = new Realm();
+  const f1 = new r.global.Function('a=1', goodFunc);
+  t.equal(f1(), 2);
+  t.end();
+});
+
+test('function-rest-parameters', t => {
+  const goodFunc = 'return rest[0] + rest[1]';
+  const r = new Realm();
+  const f1 = new r.global.Function('...rest', goodFunc);
+  t.equal(f1(1, 2), 3);
+  t.end();
+});
+
+test('function-destructuring-parameters', t => {
+  const goodFunc = 'return foo + bar + baz';
+  const r = new Realm();
+  const f1 = new r.global.Function('{foo, bar}, baz', goodFunc);
+  t.equal(f1({ foo: 1, bar: 2 }, 3), 6);
+  t.end();
+});

--- a/shim/test/realm/function-injection.js
+++ b/shim/test/realm/function-injection.js
@@ -1,0 +1,23 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+
+test('function-injection', t => {
+  const goodFunc = 'return a+1';
+  const r = new Realm();
+  const f1 = new r.global.Function('a', goodFunc);
+  t.equal(f1(5), 6);
+
+  // the naive expansion is: '(function(a) {'  +  evilFunc  +  '})'
+  // e.g. `(function(a) { ${evilFunc} })`
+
+  // we want to trick that into defining one function and evaluating
+  // something else (which is evil)
+  // like: '(function(a) {'  +  '}, this.haha = 666, {'  +  '})'
+  // which becomes: (function(a) {}, this.haha = 666, {})
+
+  const evilFunc = '}, this.haha = 666, {';
+  t.throws(() => new r.global.Function('a', evilFunc), r.global.SyntaxError);
+  t.equal(r.global.haha, undefined);
+
+  t.end();
+});


### PR DESCRIPTION
(this is based upon PR #104, so best to land it after landing that)

This fixes an injection attack in the child Realm's `Function` constructor which would admit side-effecting code in what ought to be a side-effect-free function call. The attack wouldn't reveal the parent Realm's primordials, however it would prevent the child Realm from protecting itself when using `new Function` to check whether an untrusted string is a syntactically-valid function body.

It also renames many of the evaluators for clarity, per @erights 's advice.