### PR TITLE
shim: avoid making cycles in repairFunction

### DIFF
--- a/shim/src/commons.js
+++ b/shim/src/commons.js
@@ -6,19 +6,22 @@ export const {
   assign,
   create,
   defineProperties,
+  defineProperty,
   freeze,
+  getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
-  getOwnPropertyNames
+  getOwnPropertyNames,
+  getPrototypeOf,
+  setPrototypeOf
 } = Object;
+
+// TODO: if we use Reflect.* and it returns false, we should either inspect
+// the failure, or use Object.* instead.
 
 export const {
   apply,
-  defineProperty,
   deleteProperty,
-  getOwnPropertyDescriptor,
-  getPrototypeOf,
-  ownKeys,
-  setPrototypeOf
+  ownKeys // similar but different than Object.ownKeys
 } = Reflect;
 
 export const objectHasOwnProperty = Object.prototype.hasOwnProperty;

--- a/shim/src/functions.js
+++ b/shim/src/functions.js
@@ -42,10 +42,10 @@ function repairFunction(unsafeRec, functionName, functionDecl) {
   });
   defineProperty(FunctionPrototype, 'constructor', { value: TamedFunction });
 
-  // Ensures that all functions meet "instanceof Function" in a realm.
-  setPrototypeOf(TamedFunction, unsafeFunction.prototype.constructor);
-  // todo: why does this work? it used to be done only for 'Function', but by
-  // doing it on all types, it should set up a circular prototype chain
+  if (TamedFunction !== unsafeFunction.prototype.constructor) {
+    // Ensures that all functions meet "instanceof Function" in a realm.
+    setPrototypeOf(TamedFunction, unsafeFunction.prototype.constructor);
+  }
 }
 
 /**


### PR DESCRIPTION
Use `Object.*` instead of `Reflect.*` to catch more errors like this.