### PR TITLE
Fix npm-scripts for shim:build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "scripts": {
         "build": "ecmarkup spec/index.emu index.html --css ecmarkup.css --js ecmarkup.js",
         "watch": "ecmarkup --watch spec/index.emu index.html --css ecmarkup.css --js ecmarkup.js",
-        "shim:build": "yarn shim:build:dev && yarn shim:build:prod",
-        "shim:watch": "yarn run shim:build:dev --watch",
+        "shim:build": "npm run shim:build:dev && npm run shim:build:prod",
+        "shim:watch": "npm run shim:build:dev --watch",
         "shim:build:dev": "cross-env NODE_ENV=development rollup -c shim/rollup.config.js",
         "shim:build:prod": "cross-env NODE_ENV=production rollup -c shim/rollup.config.js",
         "shim:lint": "eslint ./shim/src/**/*.js ./shim/test/**/*.js",

--- a/shim/README.md
+++ b/shim/README.md
@@ -16,7 +16,7 @@ The current implementation has 3 main limitations:
 git clone https://github.com/tc39/proposal-realms.git
 cd proposal-realms
 npm install
-npm run build-shim
+npm run shim:build
 ```
 
 This will install the necessary dependencies and build the shim locally.


### PR DESCRIPTION
`shim:build` and `shim:watch` is depending on `yarn`. It seems to be unnecessary and can replace with `npm`.
Also, I've fixed the setup instruction for shim correctly.

Thanks!