### PR TITLE
commons: use faster implementation of uncurryThis()

### DIFF
--- a/shim/src/commons.js
+++ b/shim/src/commons.js
@@ -26,8 +26,13 @@ export const {
 
 // See http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
 // which only lives at http://web.archive.org/web/20160805225710/http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
-const bind = Function.prototype.bind;
-const uncurryThis = bind.bind(bind.call);
+// (the native call is about 10x faster on FF than chrome)
+// this version of uncurryThis is about 100x slower on FF, equal on chrome, 2x slower on Safari
+// const bind = Function.prototype.bind;
+// const uncurryThis = bind.bind(bind.call);
+
+// this version is about 10x slower on FF, equal on chrome, 2x slower on Safari
+const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
 
 // We also capture these for security: changes to Array.prototype after the
 // Realm shim runs shouldn't affect subsequent Realm operations.


### PR DESCRIPTION
This version should be faster on most platforms.