### PR TITLE
shim: evaluate() should yield a useful stack trace

### DIFF
--- a/shim/src/evaluators.js
+++ b/shim/src/evaluators.js
@@ -226,7 +226,6 @@ export function createFunctionEvaluator(unsafeRec, safeEval) {
   // Ensure that any function created in any compartment in a root realm is an
   // instance of Function in any compartment of the same root ralm.
   defineProperty(safeFunction, 'prototype', { value: unsafeFunction.prototype });
-  // todo: write a test case
 
   // Provide a custom output without overwriting the Function.prototype.toString
   // which is called by some third-party libraries.

--- a/shim/src/realmFacade.js
+++ b/shim/src/realmFacade.js
@@ -27,7 +27,7 @@ function buildChildRealm(BaseRealm) {
         // err is a primitive value, which is safe to rethrow
         throw err;
       }
-      let eName, eMessage;
+      let eName, eMessage, eStack;
       try {
         // The child environment might seek to use 'err' to reach the
         // parent's intrinsics and corrupt them. `${err.name}` will cause
@@ -41,16 +41,21 @@ function buildChildRealm(BaseRealm) {
         // they aren't useful for an attack.
         eName = `${err.name}`;
         eMessage = `${err.message}`;
-        // eName and eMessage are now child-realm primitive strings, and safe
-        // to expose
+        eStack = `${err.stack}`;
+        // eName/eMessage/eStack are now child-realm primitive strings, and
+        // safe to expose
       } catch (ignored) {
         // if err.name.toString() throws, keep the (parent realm) Error away
         // from the child
         throw new Error('unknown error');
       }
       const ErrorConstructor = errorConstructors.get(eName) || Error;
-      // note: this drops the stack trace. todo: stringify and copy
-      throw new ErrorConstructor(eMessage);
+      try {
+        throw new ErrorConstructor(eMessage);
+      } catch (err2) {
+        err2.stack = eStack; // replace with the captured inner stack
+        throw err2;
+      }
     }
   }
 

--- a/shim/test/realm/function-eval.js
+++ b/shim/test/realm/function-eval.js
@@ -22,6 +22,41 @@ test('function-injection', t => {
   t.end();
 });
 
+test('function-injection-2', t => {
+  const r = Realm.makeRootRealm();
+  let flag = false;
+  r.global.target = function() {
+    flag = true;
+  };
+  function check(...args) {
+    t.throws(() => r.global.Function(...args), r.global.SyntaxError, args);
+    t.equal(flag, false);
+  }
+  function checkNotError(...args) {
+    r.global.Function(...args);
+    t.equal(flag, false);
+  }
+
+  // test cases from https://code.google.com/archive/p/google-caja/issues/1616
+  check(`}), target(), (function(){`);
+  check(`})); }); target(); (function(){ ((function(){ `);
+
+  // and from https://bugs.chromium.org/p/v8/issues/detail?id=2470
+  check('/*', '*/){');
+  check('', '});(function(){');
+  checkNotError('//', '//');
+  check('', `});print('1+1=' + (1+1));(function(){`);
+
+  // and from https://bugs.webkit.org/show_bug.cgi?id=106160
+  check('){});(function(', '');
+  check('', '});(function(){');
+  checkNotError('//', '//');
+  check('/*', '*/){');
+  check('}}; 1 * {a:{');
+
+  t.end();
+});
+
 test('function-reject-paren-default', t => {
   // this ought to be accepted, but our shim is conservative about parenthesis
   const r = Realm.makeRootRealm();

--- a/shim/test/realm/identity-compartment.js
+++ b/shim/test/realm/identity-compartment.js
@@ -50,10 +50,11 @@ test('identity eval', t => {
 
 // Function is realm-specific
 test('identity Function', t => {
-  t.plan(8);
+  t.plan(11);
 
   const r1 = Realm.makeRootRealm();
   const r2 = r1.global.Realm.makeCompartment();
+  const r3 = r1.global.Realm.makeCompartment();
 
   t.ok(r2.evaluate('Function instanceof Function'));
   t.ok(r2.evaluate('Function instanceof Object'));
@@ -63,4 +64,9 @@ test('identity Function', t => {
   t.notOk(r2.evaluate('Function') instanceof Object);
   t.notEqual(r2.evaluate('Function'), r1.evaluate('Function'));
   t.notEqual(r2.evaluate('Function'), Function);
+
+  const f2 = r2.evaluate('function x(a, b) { return a+b; }; x');
+  t.ok(f2 instanceof r1.global.Function);
+  t.ok(f2 instanceof r2.global.Function);
+  t.ok(f2 instanceof r3.global.Function);
 });

--- a/shim/test/realm/identity-single.js
+++ b/shim/test/realm/identity-single.js
@@ -40,7 +40,7 @@ test('identity eval', t => {
 
 // Function is realm-specific
 test('identity Function', t => {
-  t.plan(4);
+  t.plan(5);
 
   const r = Realm.makeRootRealm();
 
@@ -48,4 +48,7 @@ test('identity Function', t => {
   t.ok(r.evaluate('Function instanceof Object'));
   t.notOk(r.evaluate('Function') instanceof Function);
   t.notOk(r.evaluate('Function') instanceof Object);
+
+  const f = r.evaluate('function x(a, b) { return a+b; }; x');
+  t.ok(f instanceof r.global.Function);
 });

--- a/shim/test/realm/leak-error.js
+++ b/shim/test/realm/leak-error.js
@@ -81,3 +81,22 @@ test('eval() with non-parsable string should not leak SyntaxError', t => {
   t.ok(e instanceof r.global.SyntaxError);
   t.end();
 });
+
+test('eval() should yield useful stack trace', t => {
+  const r = Realm.makeRootRealm();
+  // t.throws() doesn't provide a way to look a e.stack
+  function outer8155() {
+    r.evaluate('function inner9184() { throw TypeError("yes1773"); } inner9184()');
+  }
+  try {
+    outer8155();
+    t.fail('should have thrown');
+  } catch (e) {
+    t.assert(e instanceof TypeError);
+    const stack = e.stack;
+    // stack should contain both inner and outer stacks
+    t.notEqual(stack.indexOf('outer8155'), -1); // outer
+    t.notEqual(stack.indexOf('inner9184'), -1); // inner
+  }
+  t.end();
+});


### PR DESCRIPTION
Also improve testing of Function identities and escape attempts.