### PR TITLE
Non-class API, add shims

### DIFF
--- a/shim/src/accessors.js
+++ b/shim/src/accessors.js
@@ -84,4 +84,4 @@ export function repairAccessors() {
   });
 }
 
-export const repairAccessorsShim = `${repairAccessors} repairAccessors();`;
+export const repairAccessorsShim = `(${repairAccessors})();`;

--- a/shim/src/commons.js
+++ b/shim/src/commons.js
@@ -41,5 +41,6 @@ export const objectHasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty)
   arrayPush = uncurryThis(Array.prototype.push),
   arrayPop = uncurryThis(Array.prototype.pop),
   arrayJoin = uncurryThis(Array.prototype.join),
+  arrayConcat = uncurryThis(Array.prototype.concat),
   regexpMatch = uncurryThis(RegExp.prototype.match),
   stringIncludes = uncurryThis(String.prototype.includes);

--- a/shim/src/realm.js
+++ b/shim/src/realm.js
@@ -46,8 +46,6 @@ function getRealmRecForRealmInstance(realm) {
     // Detect non-objects.
     throw new TypeError('bad object, not a Realm instance');
   }
-  // spec just says throw TypeError
-  // todo: but shim should include a message
   if (!RealmRecForRealmInstance.has(realm)) {
     // Realm instance has no realmRec. Should not proceed.
     throw new TypeError(
@@ -62,8 +60,6 @@ function registerRealmRecForRealmInstance(realm, realmRec) {
     // Detect non-objects.
     throw new TypeError('internal error: bad object, not a Realm instance');
   }
-  // spec just says throw TypeError
-  // todo: but shim should include a message
   if (RealmRecForRealmInstance.has(realm)) {
     // Attempt to change an existing realmRec on a realm instance. Should not proceed.
     throw new TypeError('internal error: Realm instance is already present');
@@ -133,9 +129,9 @@ function initRootRealm(selfClass, self, options) {
   registerRealmRecForRealmInstance(self, realmRec);
   // Now run all shims in the new RootRealm. We don't do this for
   // compartments
-  for (const s of allShims) {
+  for (const shim of allShims) {
     // eslint-disable-next-line no-use-before-define
-    realmEvaluate(self, s);
+    realmEvaluate(self, shim);
   }
 }
 

--- a/shim/src/realmFacade.js
+++ b/shim/src/realmFacade.js
@@ -4,7 +4,7 @@
 // buildChildRealm is immediately turned into a string, and this function is
 // never referenced again, because it closes over the wrong intrinsics
 
-function buildChildRealm(BaseRealm) {
+function buildChildRealm({ initRootRealm, initCompartment, getRealmGlobal, realmEvaluate }) {
   // This Object and Reflect are brand new, from a new unsafeRec, so no user
   // code has been run or had a chance to manipulate them. We extract these
   // properties for brevity, not for security. Don't ever run this function
@@ -64,20 +64,15 @@ function buildChildRealm(BaseRealm) {
     }
   }
 
-  const baseInitializeRootRealm = BaseRealm.initializeRootRealm;
-  const baseInitializeCompartment = BaseRealm.initializeCompartment;
-  const baseGetGlobal = BaseRealm.getGlobal;
-  const baseEvaluate = BaseRealm.evaluate;
-
   class Realm {
     static makeRootRealm(...args) {
       const r = new Realm();
-      callAndWrapError(baseInitializeRootRealm, Realm, r, ...args);
+      callAndWrapError(initRootRealm, Realm, r, ...args);
       return r;
     }
     static makeCompartment(...args) {
       const r = new Realm();
-      callAndWrapError(baseInitializeCompartment, Realm, r, ...args);
+      callAndWrapError(initCompartment, Realm, r, ...args);
       return r;
     }
 
@@ -90,11 +85,11 @@ function buildChildRealm(BaseRealm) {
       // baseGetGlobal immediately does a trademark check (it fails unless
       // this 'this' is present in a weakmap that is only populated with
       // legitimate Realm instances)
-      return callAndWrapError(baseGetGlobal, this);
+      return callAndWrapError(getRealmGlobal, this);
     }
     evaluate(...args) {
       // safe against strange 'this', as above
-      return callAndWrapError(baseEvaluate, this, ...args);
+      return callAndWrapError(realmEvaluate, this, ...args);
     }
   }
 

--- a/shim/src/unsafeRec.js
+++ b/shim/src/unsafeRec.js
@@ -49,14 +49,15 @@ const getNewUnsafeGlobal = isNode ? createNewUnsafeGlobalForNode : createNewUnsa
 // tied to a set of intrinsics, aka the "undeniables". If it were possible to
 // mix-and-match them from different contexts, that would enable some
 // attacks.
-function createUnsafeRec(unsafeGlobal) {
+function createUnsafeRec(unsafeGlobal, allShims) {
   const sharedGlobalDescs = getSharedGlobalDescs(unsafeGlobal);
 
   return freeze({
     unsafeGlobal,
     sharedGlobalDescs,
     unsafeEval: unsafeGlobal.eval,
-    unsafeFunction: unsafeGlobal.Function
+    unsafeFunction: unsafeGlobal.Function,
+    allShims
   });
 }
 
@@ -71,9 +72,9 @@ function sanitizeUnsafeRec(unsafeRec) {
 
 // Create a new unsafeRec from a brand new context, with new intrinsics and a
 // new global object
-export function createNewUnsafeRec() {
+export function createNewUnsafeRec(allShims) {
   const unsafeGlobal = getNewUnsafeGlobal();
-  const unsafeRec = createUnsafeRec(unsafeGlobal);
+  const unsafeRec = createUnsafeRec(unsafeGlobal, allShims);
   sanitizeUnsafeRec(unsafeRec);
   return unsafeRec;
 }
@@ -82,7 +83,7 @@ export function createNewUnsafeRec() {
 // being parsed and executed, aka the "Primal Realm"
 export function createCurrentUnsafeRec() {
   const unsafeGlobal = (0, eval)(unsafeGlobalSrc);
-  const unsafeRec = createUnsafeRec(unsafeGlobal);
+  const unsafeRec = createUnsafeRec(unsafeGlobal, []); // todo: fixAccessors here
   sanitizeUnsafeRec(unsafeRec);
   return unsafeRec;
 }

--- a/shim/test/realm/test-shims.js
+++ b/shim/test/realm/test-shims.js
@@ -1,0 +1,56 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+
+test('shims: no options', t => {
+  Realm.makeRootRealm();
+  t.end();
+});
+
+test('shims: empty options', t => {
+  Realm.makeRootRealm({});
+  t.end();
+});
+
+test('shims: no shims', t => {
+  Realm.makeRootRealm({ shims: [] });
+  t.end();
+});
+
+function addKilroy(global) {
+  global.kilroy = 'was here';
+}
+const shim1 = `${addKilroy} addKilroy(this)`;
+const shim2 = `this.kilroy += ' but he left';`;
+
+test('shims: one shim', t => {
+  const r = Realm.makeRootRealm({ shims: [shim1] });
+  t.equal(r.global.kilroy, 'was here');
+  t.end();
+});
+
+test('shims: two shims', t => {
+  const r = Realm.makeRootRealm({ shims: [shim1, shim2] });
+  t.equal(r.global.kilroy, 'was here but he left');
+  t.end();
+});
+
+test('shims: inherited shims', t => {
+  const r1 = Realm.makeRootRealm({ shims: [shim1] });
+  const r2 = r1.evaluate(`Realm.makeRootRealm({shims: [${JSON.stringify(shim2)}]})`);
+  t.equal(r1.global.kilroy, 'was here');
+  t.equal(r2.global.kilroy, 'was here but he left');
+
+  const r3root = r2.evaluate(`Realm.makeRootRealm()`);
+  t.equal(r3root.global.kilroy, 'was here but he left');
+
+  // compartments have their own global, so they don't take shims
+  const r3compartment = r2.evaluate(`Realm.makeCompartment()`);
+  t.equal(r3compartment.global.kilroy, undefined);
+
+  // but a new RootRealm *under* that compartment *should* get the shims of
+  // the nearest enclosing RootRealm
+  const r4 = r3compartment.evaluate(`Realm.makeRootRealm()`);
+  t.equal(r4.global.kilroy, 'was here but he left');
+
+  t.end();
+});


### PR DESCRIPTION
This changes the main API from `new Realm` to `Realm.makeRootRealm()` and `Realm.makeCompartment()`. It also adds a `shims` option, which provides a list of strings that will be injected into the new RootRealm (as well as every RootRealm created underneath it).

The code that repairs accessors was transformed into a default shim string, to avoid leaking the prototypes.
