### PR TITLE
reject dynamic import expressions in eval() and new Function()

### DIFF
--- a/shim/src/block-imports.js
+++ b/shim/src/block-imports.js
@@ -1,0 +1,19 @@
+// this \s *must* match all kinds of syntax-defined whitespace. If e.g.
+// U+2028 (LINE SEPARATOR) or U+2029 (PARAGRAPH SEPARATOR) is treated as
+// whitespace by the parser, but not matched by /\s/, then this would admit
+// an attack like: import\u2028('power.js') . We're trying to distinguish
+// something like that from something like importnotreally('power.js') which
+// is perfectly safe.
+
+const scanner = /^(.*)\bimport\s*(\(|\/\/|\/\*)/m;
+
+export function rejectImportExpressions(s) {
+  const matches = scanner.exec(s);
+  if (matches) {
+    // todo: if we have a full parser available, use it here. If there is no
+    // 'import' token in the string, we're safe.
+    // if (!parse(s).contains('import')) return;
+    const linenum = matches[1].split('\n').length; // more or less
+    throw new SyntaxError(`possible import expression rejected around line ${linenum}`);
+  }
+}

--- a/shim/src/evaluators.js
+++ b/shim/src/evaluators.js
@@ -17,6 +17,7 @@ import {
   stringIncludes
 } from './commons';
 import { ScopeHandler } from './scopeHandler';
+import { rejectImportExpressions } from './block-imports';
 import { assert, throwTantrum } from './utilities';
 
 const identifierPattern = /^[a-zA-Z_$][\w_$]*$/;
@@ -132,6 +133,7 @@ export function createSafeEvaluator(unsafeRec, safeGlobal) {
   const safeEval = {
     eval(src) {
       src = `${src}`;
+      rejectImportExpressions(src);
       scopeHandler.useUnsafeEvaluator = true;
       let err;
       try {

--- a/shim/test/realm/test-import-expression.js
+++ b/shim/test/realm/test-import-expression.js
@@ -1,0 +1,123 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+import { rejectImportExpressions } from '../../src/block-imports';
+
+function codepointIsSyntacticWhitespace(i) {
+  const c = String.fromCodePoint(i);
+  const f = `let a = 1; (a === ${c}a${c})`;
+  try {
+    return eval(f); // true means whitespace, false means non-whitespace
+  } catch (e) {
+    return false; // exception means non-whitespace
+  }
+}
+
+function codepointIsRegExpWhitespace(i) {
+  return /\s/m.test(String.fromCodePoint(i));
+}
+
+test('whitespace codepoints', t => {
+  // this takes about 35s to run on my laptop, and only tells us about the
+  // platform (not the shim code), so it's disabled
+  return t.end();
+  // eslint-disable-next-line no-unreachable
+  const failures = [];
+  const maxCodepoint = 0x10ffff + 1;
+  for (let i = 0; i < maxCodepoint; i++) {
+    if (i % 1024 === 0) {
+      // eslint-disable-next-line no-console
+      console.log(`U+${i.toString(16)}`);
+    }
+    const s = codepointIsSyntacticWhitespace(i);
+    const r = codepointIsRegExpWhitespace(i);
+    if (s !== r) {
+      // eslint-disable-next-line no-console
+      console.log(`codepoint 0x${i.toString(16)}: syntax ${s}, regexp ${r}`);
+      failures.push(i);
+    }
+  }
+  t.equal(failures.length, 0);
+  t.end();
+});
+
+const safe = `const a = 1`;
+
+const safe2 = `const a = notimport('evil')`;
+
+const safe3 = `const a = importnot('evil')`;
+
+const obvious = `const a = import('evil')`;
+
+const whitespace = `const a = import ('evil')`;
+
+const comment = `const a = import/*hah*/('evil')`;
+
+const doubleslashcomment = `const a = import // hah
+('evil')`;
+
+const newline = `const a = import
+('evil')`;
+
+test('no-import-expression regexp', t => {
+  // note: we cannot define these as regular functions (and then stringify)
+  // because the 'esm' module loader that we use for running the tests (i.e.
+  // 'tape -r esm ./shim/test/**/*.js') sees the 'import' statements and
+  // rewrites them.
+
+  t.equal(rejectImportExpressions(safe), undefined, 'safe');
+  t.equal(rejectImportExpressions(safe2), undefined, 'safe2');
+  t.equal(rejectImportExpressions(safe3), undefined, 'safe3');
+  t.throws(() => rejectImportExpressions(obvious), SyntaxError, 'obvious');
+  t.throws(() => rejectImportExpressions(whitespace), SyntaxError, 'whitespace');
+  t.throws(() => rejectImportExpressions(comment), SyntaxError, 'comment');
+  t.throws(() => rejectImportExpressions(doubleslashcomment), SyntaxError, 'doubleslashcomment');
+  t.throws(() => rejectImportExpressions(newline), SyntaxError, 'newline');
+
+  // mentioning import() in a comment *should* be safe, but requires a full
+  // parser to check, and a cheap regexp test will conservatively reject it.
+  // So we don't assert that behavior one way or the other
+
+  t.end();
+});
+
+test('reject import expressions in evaluate', t => {
+  const r = Realm.makeRootRealm();
+
+  function wrap(s) {
+    return `
+      function name() {
+        ${s};
+        return a;
+      }`;
+  }
+
+  t.equal(r.evaluate(wrap(safe)), undefined, 'safe');
+  t.equal(r.evaluate(wrap(safe2)), undefined, 'safe2');
+  t.equal(r.evaluate(wrap(safe3)), undefined, 'safe3');
+  t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
+  t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
+  t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.throws(() => r.evaluate(wrap(doubleslashcomment)), SyntaxError, 'doubleslashcomment');
+  t.throws(() => r.evaluate(wrap(newline)), SyntaxError, 'newline');
+
+  t.end();
+});
+
+test('reject import expressions in Function', t => {
+  const r = Realm.makeRootRealm();
+
+  function wrap(s) {
+    return `new Function("${s}; return a;")`;
+  }
+
+  r.evaluate(wrap(safe));
+  r.evaluate(wrap(safe2));
+  r.evaluate(wrap(safe3));
+  t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
+  t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
+  t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.throws(() => r.evaluate(wrap(doubleslashcomment)), SyntaxError, 'doubleslashcomment');
+  t.throws(() => r.evaluate(wrap(newline)), SyntaxError, 'newline');
+
+  t.end();
+});


### PR DESCRIPTION
We originally considered doing this as part of a shim that would be injected
into each new RootRealm (wrapping the eval/Function globals), but there are
too many cases to do this easily. Now we just apply it in all RootRealms when
building the safe evaluator.

We use a conservative regexp to spot 'import' keywords. This will reject
several safe forms, including commented out import() calls (making them
taboo: even talking about a dynamic import will cause the script to be
rejected). If/when a full parser is available, we should be able to make this
safe and accurate.

We do not look for `import.`, since 'import.meta' is not allowed in script
contexts, so we don't need to guard against it.

The security of this regexp depends it matching the behavior of the parser,
specifically they must agree on what qualifies as whitespace. There is a test
case that exhaustively checks all unicode code points for agreement, but it
takes too long to every time (35s on my laptop), so it's disabled. We should
run it at least once on any new platform to make sure there are no surprises.