### PR TITLE
Add endowments as second argument to r.evaluate()

### DIFF
--- a/shim/src/scopeHandler.js
+++ b/shim/src/scopeHandler.js
@@ -69,8 +69,13 @@ export class ScopeHandler {
   // eslint-disable-next-line class-methods-use-this
   set(target, prop, value) {
     // Set the value on the shadow. The target itself is an empty
-    // object that is only used to prevent a froxen eval property.
+    // object that is only used to prevent a frozen eval property.
     // todo: use this.shadowTarget, for speedup
+
+    // new todo: allow modifications when target.hasOwnProperty(prop) and it
+    // is writable, assuming we've already rejected overlap (see
+    // createSafeEvaluatorFactory.factory). This TypeError gets replaced with
+    // target[prop] = value
     if (objectHasOwnProperty(target, prop)) {
       // todo: shim integrity: TypeError, String
       throw new TypeError(`do not modify endowments like ${String(prop)}`);

--- a/shim/src/scopeHandler.js
+++ b/shim/src/scopeHandler.js
@@ -11,7 +11,7 @@
 // * hide the unsafeGlobal which lives on the scope chain above the 'with'
 // * ensure the Proxy invariants despite some global properties being frozen
 
-import { getPrototypeOf } from './commons';
+import { getPrototypeOf, objectHasOwnProperty } from './commons';
 
 export class ScopeHandler {
   // Properties stored on the handler are not available from the proxy.
@@ -49,6 +49,7 @@ export class ScopeHandler {
       return target.eval;
     }
 
+    // todo: shim integrity, capture Symbol.unscopables
     if (prop === Symbol.unscopables) {
       // Safe to return a primal realm Object here because the only code that
       // can do a get() on a non-string is the internals of with() itself,
@@ -70,6 +71,10 @@ export class ScopeHandler {
     // Set the value on the shadow. The target itself is an empty
     // object that is only used to prevent a froxen eval property.
     // todo: use this.shadowTarget, for speedup
+    if (objectHasOwnProperty(target, prop)) {
+      // todo: shim integrity: TypeError, String
+      throw new TypeError(`do not modify endowments like ${String(prop)}`);
+    }
     getPrototypeOf(target)[prop] = value;
     // Return true after successful set.
     return true;

--- a/shim/test/realm/test-endowments.js
+++ b/shim/test/realm/test-endowments.js
@@ -1,0 +1,43 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+
+test('eval-with-endowments', t => {
+  const r = Realm.makeRootRealm();
+  t.equal(r.evaluate(`endow1 + 2`, { endow1: 1 }), 3);
+
+  t.end();
+});
+
+test('endowments are not shared between calls to r.evaluate', t => {
+  const r = Realm.makeRootRealm();
+  t.equal(r.evaluate(`4`, { endow1: 1 }), 4);
+  t.throws(() => r.evaluate(`endow1`), ReferenceError);
+  t.throws(() => r.evaluate(`endow2`), ReferenceError);
+
+  t.end();
+});
+
+test('endowments are mutable but not shared between calls to r.evaluate', t => {
+  const r = Realm.makeRootRealm();
+  // fixed a bug: the Handlers 'get' finds the property on the target (which
+  // has the endowments), the subsequent 'set' modifies it on the safeGlobal
+  // (via getPrototypeOf(target)), then the next 'get' pulls the original
+  // value from the target again
+  // t.equal(r.evaluate(`endow1 = 4; endow1`, { endow1: 1 }), 4);
+
+  // we fixed this by rejecting assignments to endowments
+  t.throws(() => r.evaluate(`endow1 = 4`, { endow1: 1 }), TypeError);
+  t.throws(() => r.evaluate(`endow1 += 4`, { endow1: 1 }), TypeError);
+  t.throws(() => r.evaluate(`endow1`), ReferenceError);
+
+  // assignment to global works even when an endowment shadows it
+  t.equal(r.evaluate(`this.endow1 = 4; this.endow1`, { endow1: 1 }), 4);
+
+  // the modified global is now visible when there is no endowment to shadow it
+  t.equal(r.evaluate(`endow1`), 4);
+
+  // endowments shadow globals
+  t.equal(r.evaluate(`endow1`, { endow1: 44 }), 44);
+
+  t.end();
+});


### PR DESCRIPTION
This is built on top of #138, so we might want to rebase it after that lands, making the first commit (14dfd42) redundant.

This adds a second argument to `r.evaluate()` that accepts an `endowments` object, whose properties are copied into the global lexical scope for the code being evaluated.
