### PR TITLE
Shim repair functions

### DIFF
--- a/shim/src/accessors.js
+++ b/shim/src/accessors.js
@@ -86,5 +86,3 @@ export function repairAccessors() {
     }
   });
 }
-
-export const repairAccessorsShim = `(${repairAccessors})();`;

--- a/shim/src/functions.js
+++ b/shim/src/functions.js
@@ -3,83 +3,92 @@
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/startSES.js
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
 
-import { defineProperty, defineProperties, getPrototypeOf, setPrototypeOf } from './commons';
-
 /**
- * The process to repair constructors:
- * 1. Obtain the prototype from an instance of the syntax
- * 2. Create a substitute noop constructor
- * 3. Replace its prototype property with the original prototype
- * 4. Replace its prototype property's constructor with itself
- * 5. Replace its [[Prototype]] slot with the noop constructor of Function
+ * This block replaces the original Function constructor, and the original
+ * %GeneratorFunction% %AsyncFunction% and %AsyncGeneratorFunction%, with
+ * safe replacements that throw if invoked. 
+ *
+ * These are all reachable via syntax, so it isn't sufficient to just 
+ * replace global properties with safe versions. Our main goal is to prevent 
+ * access to the Function constructor through these starting points.
+
+ * After this block is done, the originals must no longer be reachable, unless 
+ * a copy has been made, and funtions can only be created by syntax (using eval) 
+ * or by invoking a previously saved reference to the originals.
  */
 
 // todo: This function is serialized and evaluated outside of the primal
 // realms and it currently can't contain code coverage metrics.
 /* istanbul ignore file */
-function repairFunction(unsafeRec, functionName, functionDecl) {
-  const { unsafeEval, unsafeFunction, unsafeGlobal } = unsafeRec;
+export function repairFunctions() {
+  const { defineProperty, getPrototypeOf, setPrototypeOf } = Object;
 
-  let FunctionInstance;
-  try {
-    // todo: pass the whole functionDecl in, rather than building a template
-    // around it, make this look like createOptionalSyntax in intrinsics.js
-    FunctionInstance = unsafeEval(functionDecl); // step 1
-  } catch (e) {
-    if (e instanceof unsafeGlobal.SyntaxError) {
-      // Prevent failure on platforms where generators are not supported.
-      return;
+  /**
+   * The process to repair constructors:
+   * 1. Create an instance of the function by evaluating syntax
+   * 2. Obtain the prototype from the instance
+   * 3. Create a substitute tamed constructor
+   * 4. Replace the original constructor with the tamed constructor
+   * 5. Replace tamed constructor prototype property with the original one
+   * 6. Replace its [[Prototype]] slot with the tamed constructor of Function
+   */
+  function repairFunction(name, declaration) {
+    let FunctionInstance;
+    try {
+      // Use Function() because eval() has issues with serializing functions under the esm module.
+      // TODO: investigate esm distortion of source code.
+      // eslint-disable-next-line no-new-func
+      FunctionInstance = Function(`return ${declaration}`)();
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        // Prevent failure on platforms where async and/or generators are not supported.
+        return;
+      }
+      // Re-throw
+      throw e;
     }
-    // Re-throw
-    throw e;
-  }
-  const FunctionPrototype = getPrototypeOf(FunctionInstance);
+    const FunctionPrototype = getPrototypeOf(FunctionInstance);
 
-  // Block evaluation of source when calling constructor on the prototype of functions.
-  const TamedFunction = unsafeFunction('throw new Error("Not available");');
-  // (new Error()).constructor does not inherit from Function, because Error
-  // was defined before ES6 classes. So we don't need to repair it too.
-  // todo: what about (Error()).constructor ?
+    // Prevents the evaluation of source when calling constructor on the prototype of functions.
+    // eslint-disable-next-line no-new-func
+    const TamedFunction = Function('throw new Error("Not available");');
+    defineProperty(TamedFunction, 'name', { value: name });
 
-  // todo: in an ES6 class that does not inherit from anything, what does its
-  // constructor inherit from? We worry that it inherits from Function, in
-  // which case instances could give access to unsafeFunction. markm says
-  // we're fine: the constructor inherits from Object.prototype
+    // (new Error()).constructors does not inherit from Function, because Error
+    // was defined before ES6 classes. So we don't need to repair it too.
 
-  defineProperties(TamedFunction, {
-    name: {
-      value: functionName
-    },
-    prototype: {
-      value: FunctionPrototype
+    // (Error()).constructor inherit from Function, which gets a tamed constructor here.
+
+    // todo: in an ES6 class that does not inherit from anything, what does its
+    // constructor inherit from? We worry that it inherits from Function, in
+    // which case instances could give access to unsafeFunction. markm says
+    // we're fine: the constructor inherits from Object.prototype
+
+    // This line replaces the original constructor in the prototype chain
+    // with the tamed one. No copy of the original is peserved.
+    defineProperty(FunctionPrototype, 'constructor', { value: TamedFunction });
+
+    // This line sets the tamed constructor's prototype data property to
+    // the original one.
+    defineProperty(TamedFunction, 'prototype', { value: FunctionPrototype });
+
+    if (TamedFunction !== Function.prototype.constructor) {
+      // Ensures that all functions meet "instanceof Function" in a realm.
+      setPrototypeOf(TamedFunction, Function.prototype.constructor);
     }
-  });
-  defineProperty(FunctionPrototype, 'constructor', { value: TamedFunction });
-
-  if (TamedFunction !== unsafeFunction.prototype.constructor) {
-    // Ensures that all functions meet "instanceof Function" in a realm.
-    setPrototypeOf(TamedFunction, unsafeFunction.prototype.constructor);
   }
-}
 
-/**
- * This block replaces the original Function constructor, and the original
- * %GeneratorFunction% %AsyncFunction% and %AsyncGeneratorFunction%, with
- * safe replacements that preserve SES confinement. After this block is done,
- * the originals must no longer be reachable.
- */
-export function repairFunctions(unsafeRec) {
   // Here, the order of operation is important: Function needs to be repaired
-  // first since the other constructors need it. Note these are all reachable
-  // via syntax, so it isn't sufficient to just replace global properties
-  // with safe versions. Our main goal is to prevent access to the
-  // unsafeFunction constructor through these starting points.
-  repairFunction(unsafeRec, 'Function', '(function(){})');
+  // first since the other repaired constructors need to inherit from the tamed
+  // Function function constructor.
+
+  // note: this really wants to be part of the standard, because new
+  // constructors may be added in the future, reachable from syntax, and this
+  // list must be updated to match.
+
+  repairFunction('Function', '(function(){})');
   // "plain arrow functions" inherit from Function.prototype
-  repairFunction(unsafeRec, 'GeneratorFunction', '(function*(){})');
-  repairFunction(unsafeRec, 'AsyncFunction', '(async function(){})');
-  repairFunction(unsafeRec, 'AsyncGeneratorFunction', '(async function*(){})');
+  repairFunction('GeneratorFunction', '(function*(){})');
+  repairFunction('AsyncFunction', '(async function(){})');
+  repairFunction('AsyncGeneratorFunction', '(async function*(){})');
 }
-// note: this really wants to be part of the standard, because new
-// constructors may be added in the future, reachable from syntax, and this
-// list must be updated to match


### PR DESCRIPTION
This PR brings the two repair closer under the same shim approach to improve robustness:
- Both shims are evaled, which protect both shims from accidental identity discontinutity and exposition of unsafe objects.
- They don't take arguments or access any other globals than those available in their scope, reducing parameter passing, and accidental mismatch.
- They appear together and much earlier, as soon as the unsafe global is created, before the unsafe record creation has a chance to reference any primordial.
- They are not part of the allShims array because they are preconditions to have the realm shim execute properly in a new unsafe record. The Realm implementation will ultimately require these preconditions to be resolved in order for it to exist. Once that's the case, those shims will no longer be necessary, and will not be part of the allShims. 

Keeping them separate from other shims, and Realm-shim-only seems to make more sense.

FYI: use w=1 to ignore whitespace changes:
https://github.com/tc39/proposal-realms/pull/140/files?w=1

@warner 