### PR TITLE
Remove class weakmap

### DIFF
--- a/shim/src/realmFacade.js
+++ b/shim/src/realmFacade.js
@@ -3,7 +3,10 @@ import { cleanupSource } from './utilities';
 // buildChildRealm is immediately turned into a string, and this function is
 // never referenced again, because it closes over the wrong intrinsics
 
-export function buildChildRealm(BaseRealm) {
+// todo: This function is stringified and evaluated outside of the primal
+// realms and it currently can't contain code coverage metrics.
+/* istanbul ignore file */
+export function buildChildRealm(unsafeRec, BaseRealm) {
   const { initRootRealm, initCompartment, getRealmGlobal, realmEvaluate } = BaseRealm;
 
   // This Object and Reflect are brand new, from a new unsafeRec, so no user
@@ -80,14 +83,14 @@ export function buildChildRealm(BaseRealm) {
     static makeRootRealm(...args) {
       // Bypass the constructor.
       const r = create(Realm.prototype);
-      callAndWrapError(initRootRealm, Realm, r, ...args);
+      callAndWrapError(initRootRealm, unsafeRec, r, ...args);
       return r;
     }
 
     static makeCompartment(...args) {
       // Bypass the constructor.
       const r = create(Realm.prototype);
-      callAndWrapError(initCompartment, Realm, r, ...args);
+      callAndWrapError(initCompartment, unsafeRec, r, ...args);
       return r;
     }
 
@@ -148,5 +151,5 @@ export function createRealmFacade(unsafeRec, BaseRealm) {
   // values using the intrinsics of the realm's context.
 
   // Invoke the BaseRealm constructor with Realm as the prototype.
-  return unsafeEval(buildChildRealmString)(BaseRealm);
+  return unsafeEval(buildChildRealmString)(unsafeRec, BaseRealm);
 }


### PR DESCRIPTION
This change removes the need of private class members (implemented with a weakmap) and simply uses a closure variable which is already accessible.

This is an additional commit built on the previous PR. 

PS: After this PR, only 14 lines of code will not be covered by tests.

```
------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |    94.42 |    88.16 |       98 |    94.32 |                   |
 accessors.js     |    89.29 |     87.5 |      100 |    89.29 |          38,50,57 |
 block-imports.js |      100 |      100 |      100 |      100 |                   |
 commons.js       |      100 |      100 |      100 |      100 |                   |
 evaluators.js    |    97.96 |    90.91 |      100 |    97.87 |               110 |
 functions.js     |    82.35 |       50 |      100 |    82.35 |          39,41,44 |
 optimizer.js     |      100 |      100 |      100 |      100 |                   |
 realm.js         |      100 |      100 |      100 |      100 |                   |
 scopeHandler.js  |      100 |      100 |      100 |      100 |                   |
 stdlib.js        |      100 |      100 |      100 |      100 |                   |
 unsafeRec.js     |    77.78 |    66.67 |       80 |    77.78 | 16,35,36,38,39,47 |
 utilities.js     |      100 |      100 |      100 |      100 |                   |
------------------|----------|----------|----------|----------|-------------------|
```