### PR TITLE
shim: build TamedFunction as a strict function, not sloppy

### DIFF
--- a/shim/src/repair/functions.js
+++ b/shim/src/repair/functions.js
@@ -45,9 +45,11 @@ export function repairFunctions() {
     }
     const FunctionPrototype = getPrototypeOf(FunctionInstance);
 
-    // Prevents the evaluation of source when calling constructor on the prototype of functions.
-    // eslint-disable-next-line no-new-func
-    const TamedFunction = Function('throw new TypeError("Not available");');
+    // Prevents the evaluation of source when calling constructor on the
+    // prototype of functions.
+    const TamedFunction = function() {
+      throw new TypeError('Not available');
+    };
     defineProperties(TamedFunction, { name: { value: name } });
 
     // (new Error()).constructors does not inherit from Function, because Error

--- a/shim/test/realm/test-repair.js
+++ b/shim/test/realm/test-repair.js
@@ -54,6 +54,30 @@ test('fix the bug in which accessor methods leak the global', t => {
   t.end();
 });
 
+function getGenerator() {
+  function* aStrictGenerator() {
+    yield;
+  }
+  return Object.getPrototypeOf(aStrictGenerator);
+}
+
+test('strict-function', t => {
+  const r = Realm.makeRootRealm();
+  const c = r.evaluate('Function.prototype.constructor');
+  t.notOk('arguments' in Object.getOwnPropertyDescriptors(c));
+  t.notOk('caller' in Object.getOwnPropertyDescriptors(c));
+  t.end();
+});
+
+test('generator-constructor-is-consistent', t => {
+  const r = Realm.makeRootRealm();
+  const c = r.evaluate('Function.prototype.constructor');
+  const gf = r.evaluate(`(${getGenerator})`)();
+  const gfc = gf.constructor;
+  t.equal(Object.getPrototypeOf(gfc), c);
+  t.end();
+});
+
 // todo: rewrite and re-enable
 
 test('scan', t => {

--- a/shim/test/realm/test-repair.js
+++ b/shim/test/realm/test-repair.js
@@ -72,9 +72,9 @@ test('strict-function', t => {
 test('generator-constructor-is-consistent', t => {
   const r = Realm.makeRootRealm();
   const c = r.evaluate('Function.prototype.constructor');
-  const gf = r.evaluate(`(${getGenerator})`)();
-  const gfc = gf.constructor;
-  t.equal(Object.getPrototypeOf(gfc), c);
+  const gp = r.evaluate(`(${getGenerator})`)();
+  const gpc = gp.constructor;
+  t.equal(Object.getPrototypeOf(gpc), c);
   t.end();
 });
 


### PR DESCRIPTION
The previous use of 'Function' actually created a "sloppy-mode"
function (whereas using 'function' creates a "strict-mode" function). This
was a leak: we should not be allowing sloppy-mode functions to be accessible
within the new Realm. The sloppy-mode function had '.arguments' and '.caller'
properties, which confused the SES code that removes non-whitelisted
properties.