### PR TITLE
Fix definition of `isNode` and `isBrowser` to work with bundlers

### DIFF
--- a/shim/src/unsafeRec.js
+++ b/shim/src/unsafeRec.js
@@ -10,8 +10,8 @@ import { freeze } from './commons';
 // this feature will be provided by the underlying engine instead.
 
 // Platform detection.
-const isNode = typeof exports === 'object' && typeof module !== 'undefined';
-const isBrowser = typeof document === 'object';
+const isBrowser = new Function('try {return this===window}catch(e){ return false}')(); // eslint-disable-line no-new-func
+const isNode = new Function('try {return this===global}catch(e){ return false}')(); // eslint-disable-line no-new-func
 if ((!isNode && !isBrowser) || (isNode && isBrowser)) {
   throw new Error('unexpected platform, unable to create Realm');
 }

--- a/shim/test/module/unsafeRec.js
+++ b/shim/test/module/unsafeRec.js
@@ -5,8 +5,8 @@ import {
   createNewUnsafeGlobalForBrowser
 } from '../../src/unsafeRec';
 
-const isNode = typeof exports === 'object' && typeof module !== 'undefined';
-const isBrowser = typeof document === 'object';
+const isBrowser = new Function('try {return this===window}catch(e){ return false}')(); // eslint-disable-line no-new-func
+const isNode = new Function('try {return this===global}catch(e){ return false}')(); // eslint-disable-line no-new-func
 
 test('createNewUnsafeRec', t => {
   t.plan(7);


### PR DESCRIPTION
## Description
The Realms shim currently fails in webpack, parcel, and browserify. (SES, which relies on Realms, has failing tests for these bundlers due to this problem [here](https://circleci.com/gh/Agoric/SES/56).) This prevents the Realms shim from being useful in many JavaScript workflows.

The error message is "unexpected platform, unable to create Realm," and this is because when the output of these bundlers is run in a browser, `exports`, `module`, and `document` are all objects, and thus `isNode` and `isBrowser` are both true. 

This PR changes the definition of `isNode` and `isBrowser`. Instead of checking whether `exports`, `module`, and `document` are objects, this definition checks whether `this` is `window` or `global`. The check is wrapped in a try/catch such that a ReferenceError isn't thrown if `window` or `global` are undefined.  

Closes #188 

## Tests
`npm run shim:test`

The SES bundler tests are able to confirm that this PR solves this particular problem. 
