### PR TITLE
Fix `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{README.md,package.json,spec.html,.travis.yml}]
+[{DISCUSSIONS.md,package.json,*.yml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Both `spec.html` and `README.md` use the superior tabs for indentation.