### PR TITLE
Editioral: rename the host hook to HostInitializeSyntheticRealm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -61,7 +61,7 @@ location: https://tc39.es/proposal-realms/
 				1. Set _O_.[[ExecutionContext]] to _context_.
 				1. Perform ? SetRealmGlobalObject(_realmRec_, *undefined*, *undefined*).
 				1. Perform ? SetDefaultGlobalBindings(_O_.[[Realm]]).
-				1. Perform ? HostInitializeUserRealm(_O_.[[Realm]]).
+				1. Perform ? HostInitializeSyntheticRealm(_O_.[[Realm]]).
 				1. Return _O_.
 			</emu-alg>
 		</emu-clause>
@@ -175,10 +175,10 @@ location: https://tc39.es/proposal-realms/
 
 	<emu-clause id="sec-realm-host-operations">
 		<h1>Host operations</h1>
-		<emu-clause id="sec-host-initialize-user-realm" aoid="HostInitializeUserRealm">
-			<h1>Runtime Semantics: HostInitializeUserRealm ( _realm_ )</h1>
+		<emu-clause id="sec-host-initialize-synthetic-realm" aoid="HostInitializeSyntheticRealm">
+			<h1>Runtime Semantics: HostInitializeSyntheticRealm ( _realm_ )</h1>
 			<p>
-				HostInitializeUserRealm is an implementation-defined abstract
+				HostInitializeSyntheticRealm is an implementation-defined abstract
 				operation used to inform the host of any newly created realms from
 				the Realm constructor. Its return value is not used, though it may
 				throw an exception. The idea of this hook is to initialize host


### PR DESCRIPTION
The term "synthetic realm" is proposed to be used in the HTML/Realm
integration PR to describe the contrast with the main "principal"
Realm. This PR renames the host hook to match, and to avoid the
confusion noted in #281