### PR TITLE
Add a badge for specifying current stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ECMAScript spec proposal for Realms API
 
+![Stage 2](https://badges.aleen42.com/src/tc39_3.svg)
+
 ## <a name='Status'></a>Status
 
 - [Explainer](explainer.md).


### PR DESCRIPTION
According to https://es.discourse.group/t/a-standard-badge-for-tc39/731, automatically generate a badge for specifying current stage of the proposal.