### PR TITLE
Address review feedback 

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -98,7 +98,7 @@ location: https://tc39.es/proposal-realms/
 			1. Let _wrappedThisArgument_ to ? GetWrappedValue(_targetRealm_, _thisArgument_).
 			1. Let _result_ be the Completion Record of Call(_target_, _wrappedThisArgument_, _argumentsList_).
 			1. If _result_.[[Type]] is ~normal~ or _result_.[[Type]] is ~return~, then
-				1. Return ? GetWrappedValue(_callerRealm_, _value_).
+				1. Return ? GetWrappedValue(_callerRealm_, _result_).
 			1. Else,
 				1. Throw a newly created TypeError object associate to the _callerRealm_.
 		</emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -280,7 +280,7 @@ location: https://tc39.es/proposal-realms/
 				1. Return ? PerformRealmEval(_sourceText_, _callerRealm_, _evalRealm_).
 			</emu-alg>
 
-			<emu-note>
+			<emu-note type=editor>
 				Extensible web: This is the dynamic equivalent of a &lt;script&gt; in HTML.
 			</emu-note>
 		</emu-clause>
@@ -299,7 +299,7 @@ location: https://tc39.es/proposal-realms/
 				1. Return ? RealmImportValue(_specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_).
 			</emu-alg>
 
-			<emu-note>
+			<emu-note type=editor>
 				Extensible web: This is equivalent to dynamic import without having to evaluate a script source, which might not be available (e.g.: when CSP is blocking source evaluation).
 			</emu-note>
 		</emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -98,7 +98,6 @@ location: https://tc39.es/proposal-realms/
 			1. Let _wrappedThisArgument_ to ? GetWrappedValue(_targetRealm_, _thisArgument_).
 			1. Let _result_ be the Completion Record of Call(_target_, _wrappedThisArgument_, _argumentsList_).
 			1. If _result_.[[Type]] is ~normal~ or _result_.[[Type]] is ~return~, then
-				1. Set _value_ to _result_.[[Value]].
 				1. Return ? GetWrappedValue(_callerRealm_, _value_).
 			1. Else,
 				1. Throw a newly created TypeError object associate to the _callerRealm_.

--- a/spec.html
+++ b/spec.html
@@ -172,6 +172,9 @@ location: https://tc39.es/proposal-realms/
 			<emu-note type=editor>
 				In the case of an abrupt ~throw~ completion, the type of error to be created should match the type of the abrupt throw completion record. This could be revisited when merging into the main specification. Additionally, in the case of a ~break~ or ~continue~ completion, since those are not supported, a TypeError is expected. There should be no ~return~ completion because this is a top level script evaluation, in which case a return |Statement| must result in a parsing error.
 			</emu-note>
+			<emu-note type=editor>
+				Some thes PerformRealmEval steps are shared with |eval| and |Function| and should result into a shared abstraction when merged to ECMA-262.
+			</emu-note>
 		</emu-clause>
 
 		<emu-clause id="sec-performrealmimportvalue" aoid="PerformRealmImportValue">

--- a/spec.html
+++ b/spec.html
@@ -165,7 +165,7 @@ location: https://tc39.es/proposal-realms/
 				1. Suspend _evalContext_ and remove it from the execution context stack.
 				1. Resume the context that is now on the top of the execution context stack as the running execution context.
 				1. If _result_.[[Type]] is not ~normal~, throw a newly created TypeError object associate to the _callerRealm_.
-				1. Return ? GetWrappedValue(_callerRealm_, _result_.[[Value]]).
+				1. Return ? GetWrappedValue(_callerRealm_, _result_).
 			</emu-alg>
 			<emu-note type=editor>
 				In the case of an abrupt ~throw~ completion, the type of error to be created should match the type of the abrupt throw completion record. This could be revisited when merging into the main specification. Additionally, in the case of a ~break~ or ~continue~ completion, since those are not supported, a TypeError is expected. There should be no ~return~ completion because this is a top level script evaluation, in which case a return |Statement| must result in a parsing error.

--- a/spec.html
+++ b/spec.html
@@ -66,18 +66,18 @@ location: https://tc39.es/proposal-realms/
 			Callable Object
 		</td>
 		<td>
-			The wrapped function object.
+			Stores the callable object from the other Realm.
 		</td>
 		</tr>
 		<tr>
 		<td>
-			[[Realm]]
+			[[Call]]
 		</td>
 		<td>
-			Realm Record
+			The [[Call]] internal method
 		</td>
 		<td>
-			The realm in which the wrapped function object was created.
+			Executes code associated with this object's [[WrappedTargetFunction]].
 		</td>
 		</tr>
 		</tbody>
@@ -118,7 +118,6 @@ location: https://tc39.es/proposal-realms/
 			1. Let _obj_ be ! MakeBasicObject(_internalSlotsList_).
 			1. Set _obj_.[[Prototype]] to _callerRealm_.[[Intrinsics]].[[%Function.prototype%]].
 			1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-wrapped-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
-			1. Set _obj_.[[Realm]] to _callerRealm_.
 			1. Set _obj_.[[WrappedTargetFunction]] to _targetFunction_.
 			1. Return _obj_.
 		</emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -176,8 +176,8 @@ location: https://tc39.es/proposal-realms/
 			</emu-note>
 		</emu-clause>
 
-		<emu-clause id="sec-performrealmimportvalue" aoid="PerformRealmImportValue">
-			<h1>PerformRealmImportValue ( _specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_ )</h1>
+		<emu-clause id="sec-realmimportvalue" aoid="RealmImportValue">
+			<h1>RealmImportValue ( _specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_ )</h1>
 			<emu-alg>
 				1. Assert: Type(_specifierString_) is String.
 				1. Assert: Type(_exportNameString_) is String.
@@ -297,7 +297,7 @@ location: https://tc39.es/proposal-realms/
 				1. Let _callerRealm_ be the current Realm Record.
 				1. Let _evalRealm_ be _O_.[[Realm]].
 				1. Let _evalContext_ be _O_.[[ExecutionContext]].
-				1. Return ? PerformRealmImportValue(_specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_).
+				1. Return ? RealmImportValue(_specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_).
 			</emu-alg>
 
 			<emu-note>

--- a/spec.html
+++ b/spec.html
@@ -98,7 +98,7 @@ location: https://tc39.es/proposal-realms/
 			1. Let _wrappedThisArgument_ to ? GetWrappedValue(_targetRealm_, _thisArgument_).
 			1. Let _result_ be the Completion Record of Call(_target_, _wrappedThisArgument_, _argumentsList_).
 			1. If _result_.[[Type]] is ~normal~ or _result_.[[Type]] is ~return~, then
-				1. Set _value_ to NormalCompletion(_result_.[[Value]]).
+				1. Set _value_ to _result_.[[Value]].
 				1. Return ? GetWrappedValue(_callerRealm_, _value_).
 			1. Else,
 				1. Throw a newly created TypeError object associate to the _callerRealm_.

--- a/spec.html
+++ b/spec.html
@@ -172,7 +172,7 @@ location: https://tc39.es/proposal-realms/
 				In the case of an abrupt ~throw~ completion, the type of error to be created should match the type of the abrupt throw completion record. This could be revisited when merging into the main specification. Additionally, in the case of a ~break~ or ~continue~ completion, since those are not supported, a TypeError is expected. There should be no ~return~ completion because this is a top level script evaluation, in which case a return |Statement| must result in a parsing error.
 			</emu-note>
 			<emu-note type=editor>
-				Some thes PerformRealmEval steps are shared with |eval| and |Function| and should result into a shared abstraction when merged to ECMA-262.
+				Some steps from PerformRealmEval are shared with |eval| and |Function| and should result into a shared abstraction when merged to ECMA-262.
 			</emu-note>
 		</emu-clause>
 


### PR DESCRIPTION
Ref #304

Address review feedback from @ljharb.

---

> why do you need to wrap the completion record value in a new record, as opposed to just passing on the completion record (when its type is normal or return)?

This seems like a bug, I'm removing the Completion wrapping.

> Additionally, since the only possible types of completion record from the invocation is "abrupt" or "normal or return", it kind of seems like you could branch on whether it's abrupt, and not have to explicitly mention normal/return.

I'd say for the editorial style. If check if the type is abrupt, I'd be compelled to add an assertion step saying completion type must be normal or return to clarity it won't be "continue or break". The positive if for normal or return makes the spec steps more clear. I'd prefer to defer this decision to an eventual PR to ECMA-262 if possible.

> Can eval, Function, and https://tc39.es/proposal-realms/#sec-performrealmeval be made to maximally share steps/AOs? It seems like it'd be helpful if they could all be expressed in terms of the same operation(s).

I agree the 3 of them seem good enough to make an abstraction, but this also seems more appropriate to a PR to ECMA-262? I can add an editorial note to point out the intention.

> Should the name of the [[Realm]] slot be the same on functions and Realm instances? Perhaps it should, if it's holding the same types of values, but perhaps it'd be better to differentiate the two?

Thanks for catching this! We don't need this [[Realm]] internal in Wrapped Function Exotic Objects so I'm removing it for now. With some further review, the name would actually create weird hazard in `Realm.prototype.evaluate`. 

> "Perform" is typically the verb associated with calling an AO and ignoring any non-abrupt return value. Can https://tc39.es/proposal-realms/#sec-performrealmimportvalue start with something besides "Perform"?

Trying to not bikeshed too much over the name, I'm renaming the abstraction to RealmImportValue, an alternative would be `ImportRealmValue` but I don't think there is no perfect option here.

> I'm not sure what all the "Extensible web:" phrases are in the notes - we don't have this anywhere in the spec, and it doesn't link anywhere. What's the purpose of that note prefix?

These are just editorial notes to help connecting to the ongoing integration with HTML, I don't think they should all be part of the final PR to ECMA-262.

> In https://tc39.es/proposal-realms/#sec-hostimportmodulebindingdynamically: the "failure path" sentence reads oddly to me, and I'm not sure what it means exactly. Also, for the "success path" case, should the completion record's type be constrained to be "normal"?

Note taken. I'm gonna try to address this abstraction in a separate PR as I also have feedback from @syg about it.