### PR TITLE
Editorial: stricter notes in HostInitializeSyntheticRealm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -369,10 +369,10 @@ location: https://tc39.es/proposal-realms/
 			</p>
 			<p>
 				The host may use this hook to add properties to the Realm's global
-				object. Those properties must each be configurable to provide
-				platform capabilities with no authority to cause side effects such
-				as I/O or mutation of values that are shared across different
-				realms within the same host environment.
+				object. Those properties must be configurable. Those properties must
+				have no authority to cause side effects such as I/O or mutation of
+				values (or internal state of the host) that are shared across different
+				realms or within the same realm.
 			</p>
 			<emu-note>
 				<p>


### PR DESCRIPTION
> Those properties must each be configurable to provide platform capabilities with no authority to cause side effects such as I/O or mutation of values that are shared across different realms within the same host environment.

The current version allows the host to create a mutation of values that _not_ shared across different realms. But IMO that also violates SES requirements.

Example:

```js
// Action of the host in HostInitializeSyntheticRealm
(() => {
    let counter = 0 // internal state
    globalThis.getCounter = () => counter
    globalThis.addCounter = () => void counter++
})()
```

I changed that to:

> Those properties must be configurable. Those properties must have no authority to cause side effects such as I/O or mutation of values (or internal state of the host) that are shared across different realms or within the same realm.