### PR TITLE
Editorial: Mark WrappedFunctionCreate as infallible

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -233,7 +233,7 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. Assert: _callerRealm_ is a Realm Record.
 				1. If Type(_value_) is Object, then
 				  1. If IsCallable(_value_) is *false*, throw a TypeError exception.
-				  1. Return ? WrappedFunctionCreate(_callerRealm_, _value_).
+				  1. Return ! WrappedFunctionCreate(_callerRealm_, _value_).
 				1. Return _value_.
 			</emu-alg>
 		</emu-clause>


### PR DESCRIPTION
None of this can cause it to return an abrupt completion:

```
1. Assert: callerRealm is a Realm Record.
2. Assert: IsCallable(targetFunction) is true.
3. Let internalSlotsList be the internal slots listed in Table 2, plus [[Prototype]] and [[Extensible]].
4. Let obj be ! MakeBasicObject(internalSlotsList).
5. Set obj.[[Prototype]] to callerRealm.[[Intrinsics]].[[%Function.prototype%]].
6. Set obj.[[Call]] as described in 2.1.
7. Set obj.[[WrappedTargetFunction]] to targetFunction.
8. Set obj.[[Realm]] to callerRealm.
9. Return obj.
```